### PR TITLE
feat: static driver support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,6 @@ provider "humanitec" {
 
 ### Optional
 
-- `host` (String) Humanitec API host (also reads HUMANITEC_HOST)
-- `org_id` (String) Humanitec Organization ID (also reads HUMANITEC_ORG_ID)
-- `token` (String, Sensitive) Humanitec Token (also reads HUMANITEC_TOKEN)
+- `host` (String) Humanitec API host (or using the `HUMANITEC_HOST` environment variable)
+- `org_id` (String) Humanitec Organization ID (or using the `HUMANITEC_ORG_ID` environment variable)
+- `token` (String, Sensitive) Humanitec Token (or using the `HUMANITEC_TOKEN` environment variable)

--- a/docs/resources/resource_definition.md
+++ b/docs/resources/resource_definition.md
@@ -45,9 +45,11 @@ resource "humanitec_resource_definition" "postgres" {
     }
   }
 
-  criteria = [{
-    app_id = "test-app"
-  }]
+  criteria = [
+    {
+      app_id = "test-app"
+    }
+  ]
 }
 
 resource "humanitec_resource_definition" "gke" {

--- a/internal/provider/humanitec_client.go
+++ b/internal/provider/humanitec_client.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/humanitec/terraform-provider-humanitec/internal/client"
+)
+
+func copyBody(body io.ReadCloser) (io.ReadCloser, []byte, error) {
+	if body == nil {
+		return nil, nil, nil
+	}
+
+	var buf bytes.Buffer
+	tee := io.TeeReader(body, &buf)
+	bodyBytes, err := io.ReadAll(tee)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return io.NopCloser(bytes.NewReader(buf.Bytes())), bodyBytes, nil
+}
+
+func copyReqBody(req *http.Request) (string, error) {
+	if req.Body == nil {
+		return "", nil
+	}
+
+	body, bodyBytes, err := copyBody(req.Body)
+	if err != nil {
+		return "", err
+	}
+	req.Body = body
+
+	return string(bodyBytes), nil
+}
+
+func copyResBody(res *http.Response) (string, error) {
+	if res.Body == nil {
+		return "", nil
+	}
+
+	body, bodyBytes, err := copyBody(res.Body)
+	if err != nil {
+		return "", err
+	}
+	res.Body = body
+
+	return string(bodyBytes), nil
+}
+
+type DoWithLog struct {
+	client client.HttpRequestDoer
+}
+
+func (d *DoWithLog) Do(req *http.Request) (*http.Response, error) {
+	reqBody, err := copyReqBody(req)
+	if err != nil {
+		return nil, err
+	}
+
+	tflog.Debug(req.Context(), "api req", map[string]interface{}{"method": req.Method, "uri": req.URL.String(), "body": reqBody})
+
+	res, err := d.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	resBody, err := copyResBody(res)
+	if err != nil {
+		return nil, err
+	}
+
+	tflog.Debug(req.Context(), "api res", map[string]interface{}{"status": res.StatusCode, "body": resBody})
+
+	return res, nil
+}
+
+func NewHumanitecClient(host, token string) (*client.ClientWithResponses, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	client, err := client.NewClientWithResponses(host, func(c *client.Client) error {
+		c.Client = &DoWithLog{&http.Client{}}
+		c.RequestEditors = append(c.RequestEditors, func(_ context.Context, req *http.Request) error {
+			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+			return nil
+		})
+		return nil
+	})
+	if err != nil {
+		diags.AddError("Unable to create Humanitec client", err.Error())
+		return nil, diags
+	}
+
+	return client, diags
+}

--- a/internal/provider/humanitec_client_test.go
+++ b/internal/provider/humanitec_client_test.go
@@ -1,0 +1,68 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/humanitec/terraform-provider-humanitec/internal/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHumanitecClientRead(t *testing.T) {
+	assert := assert.New(t)
+
+	expected := "{}"
+	token := "TEST_TOKEN"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(fmt.Sprintf("Bearer %s", token), r.Header.Get("Authorization"))
+		fmt.Fprint(w, expected)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+
+	humSvc, diags := NewHumanitecClient(srv.URL, token)
+	if diags.HasError() {
+		assert.Fail("errors found", diags)
+	}
+
+	_, err := humSvc.GetCurrentUser(ctx)
+	assert.NoError(err)
+}
+
+func TestNewHumanitecClientWrite(t *testing.T) {
+	assert := assert.New(t)
+
+	expected := "{}"
+	token := "TEST_TOKEN"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(fmt.Sprintf("Bearer %s", token), r.Header.Get("Authorization"))
+
+		defer r.Body.Close()
+		resBody, err := ioutil.ReadAll(r.Body)
+		assert.NoError(err)
+		assert.Equal("{\"name\":\"changed\"}", string(resBody))
+
+		fmt.Fprint(w, expected)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+
+	humSvc, diags := NewHumanitecClient(srv.URL, token)
+	if diags.HasError() {
+		assert.Fail("errors found", diags)
+	}
+
+	name := "changed"
+	_, err := humSvc.PatchCurrentUser(ctx, client.PatchCurrentUserJSONRequestBody{
+		Name: &name,
+	})
+	assert.NoError(err)
+}

--- a/internal/provider/humanitec_data.go
+++ b/internal/provider/humanitec_data.go
@@ -15,9 +15,12 @@ type HumanitecData struct {
 
 	fetchDriversMu sync.Mutex
 	driversByType  map[string]*client.DriverDefinitionResponse
+
+	fetchTypesMu sync.Mutex
+	typesByType  map[string]*client.ResourceTypeResponse
 }
 
-func (h *HumanitecData) fetchDriversByType(ctx context.Context) (map[string]*client.DriverDefinitionResponse, diag.Diagnostics) {
+func (h *HumanitecData) fetchResourceDrivers(ctx context.Context) (map[string]*client.DriverDefinitionResponse, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	h.fetchDriversMu.Lock()
@@ -54,17 +57,92 @@ func (h *HumanitecData) fetchDriversByType(ctx context.Context) (map[string]*cli
 	return driversByType, diags
 }
 
-func (h *HumanitecData) DriverByDriverType(ctx context.Context, driverType string) (*client.DriverDefinitionResponse, diag.Diagnostics) {
-	driversByType, diags := h.fetchDriversByType(ctx)
+func (h *HumanitecData) fetchResourceTypes(ctx context.Context) (map[string]*client.ResourceTypeResponse, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	h.fetchTypesMu.Lock()
+	defer h.fetchTypesMu.Unlock()
+
+	if h.typesByType != nil {
+		return h.typesByType, diags
+	}
+
+	httpResp, err := h.Client.GetOrgsOrgIdResourcesTypesWithResponse(ctx, h.OrgID)
+	if err != nil {
+		diags.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to get resource types, got error: %s", err))
+		return nil, diags
+	}
+
+	if httpResp.StatusCode() != 200 {
+		diags.AddError(HUM_API_ERR, fmt.Sprintf("Unable to get resource types, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
+		return nil, diags
+	}
+
+	if httpResp.JSON200 == nil {
+		diags.AddError(HUM_API_ERR, fmt.Sprintf("Unable to get resource types, missing body, body: %s", httpResp.Body))
+		return nil, diags
+	}
+
+	typesByType := map[string]*client.ResourceTypeResponse{}
+	for _, d := range *httpResp.JSON200 {
+		d := d
+		typesByType[d.Type] = &d
+	}
+
+	h.typesByType = typesByType
+
+	return typesByType, diags
+}
+
+func (h *HumanitecData) driverByDriverType(ctx context.Context, driverType string) (*client.DriverDefinitionResponse, diag.Diagnostics) {
+	driversByType, diags := h.fetchResourceDrivers(ctx)
 	if diags.HasError() {
 		return nil, diags
 	}
 
 	driver, ok := driversByType[driverType]
 	if !ok {
-		diags.AddError(HUM_INPUT_ERR, fmt.Sprintf("Not resource driver found for type: %s", driverType))
+		diags.AddError(HUM_INPUT_ERR, fmt.Sprintf("No resource driver found for type: %s", driverType))
 		return nil, diags
 	}
 
 	return driver, diags
+}
+
+func (h *HumanitecData) resourceByType(ctx context.Context, resourceType string) (*client.ResourceTypeResponse, diag.Diagnostics) {
+	resourcesByType, diags := h.fetchResourceTypes(ctx)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	resource, ok := resourcesByType[resourceType]
+	if !ok {
+		diags.AddError(HUM_INPUT_ERR, fmt.Sprintf("No resource type found for type: %s", resourceType))
+		return nil, diags
+	}
+
+	return resource, diags
+}
+
+func (h *HumanitecData) DriverInputSchemaByDriverTypeOrType(ctx context.Context, driverType, resourceType string) (map[string]interface{}, diag.Diagnostics) {
+	// The static driver has no input schema and matches the output schema of the resource type
+	if driverType == "humanitec/static" {
+		resource, diags := h.resourceByType(ctx, resourceType)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		inputSchema := resource.OutputsSchema.AdditionalProperties
+
+		return inputSchema, diags
+	}
+
+	driver, diags := h.driverByDriverType(ctx, driverType)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	inputSchema := driver.InputsSchema.AdditionalProperties
+
+	return inputSchema, diags
 }

--- a/internal/provider/humanitec_data.go
+++ b/internal/provider/humanitec_data.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/humanitec/terraform-provider-humanitec/internal/client"
+)
+
+type HumanitecData struct {
+	Client *client.ClientWithResponses
+	OrgID  string
+
+	fetchDriversMu sync.Mutex
+	driversByType  map[string]*client.DriverDefinitionResponse
+}
+
+func (h *HumanitecData) fetchDriversByType(ctx context.Context) (map[string]*client.DriverDefinitionResponse, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	h.fetchDriversMu.Lock()
+	defer h.fetchDriversMu.Unlock()
+
+	if h.driversByType != nil {
+		return h.driversByType, diags
+	}
+
+	httpResp, err := h.Client.GetOrgsOrgIdResourcesDriversWithResponse(ctx, h.OrgID)
+	if err != nil {
+		diags.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to get resource drivers, got error: %s", err))
+		return nil, diags
+	}
+
+	if httpResp.StatusCode() != 200 {
+		diags.AddError(HUM_API_ERR, fmt.Sprintf("Unable to get resource drivers, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
+		return nil, diags
+	}
+
+	if httpResp.JSON200 == nil {
+		diags.AddError(HUM_API_ERR, fmt.Sprintf("Unable to get resource drivers, missing body, body: %s", httpResp.Body))
+		return nil, diags
+	}
+
+	driversByType := map[string]*client.DriverDefinitionResponse{}
+	for _, d := range *httpResp.JSON200 {
+		d := d
+		driversByType[fmt.Sprintf("%s/%s", d.OrgId, d.Id)] = &d
+	}
+
+	h.driversByType = driversByType
+
+	return driversByType, diags
+}
+
+func (h *HumanitecData) DriverByDriverType(ctx context.Context, driverType string) (*client.DriverDefinitionResponse, diag.Diagnostics) {
+	driversByType, diags := h.fetchDriversByType(ctx)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	driver, ok := driversByType[driverType]
+	if !ok {
+		diags.AddError(HUM_INPUT_ERR, fmt.Sprintf("Not resource driver found for type: %s", driverType))
+		return nil, diags
+	}
+
+	return driver, diags
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,11 +1,7 @@
 package provider
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"io"
-	"net/http"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -14,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/humanitec/terraform-provider-humanitec/internal/client"
 )
 
 // Ensure HumanitecProvider satisfies various provider interfaces.
@@ -35,11 +29,6 @@ type HumanitecProviderModel struct {
 	Host  types.String `tfsdk:"host"`
 	OrgID types.String `tfsdk:"org_id"`
 	Token types.String `tfsdk:"token"`
-}
-
-type HumanitecResourceData struct {
-	Client *client.ClientWithResponses
-	OrgID  string
 }
 
 const (
@@ -77,76 +66,6 @@ func (p *HumanitecProvider) GetSchema(ctx context.Context) (tfsdk.Schema, diag.D
 			},
 		},
 	}, nil
-}
-
-func copyBody(body io.ReadCloser) (io.ReadCloser, []byte, error) {
-	if body == nil {
-		return nil, nil, nil
-	}
-
-	var buf bytes.Buffer
-	tee := io.TeeReader(body, &buf)
-	bodyBytes, err := io.ReadAll(tee)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return io.NopCloser(bytes.NewReader(buf.Bytes())), bodyBytes, nil
-}
-
-func copyReqBody(req *http.Request) (string, error) {
-	if req.Body == nil {
-		return "", nil
-	}
-
-	body, bodyBytes, err := copyBody(req.Body)
-	if err != nil {
-		return "", err
-	}
-	req.Body = body
-
-	return string(bodyBytes), nil
-}
-
-func copyResBody(res *http.Response) (string, error) {
-	if res.Body == nil {
-		return "", nil
-	}
-
-	body, bodyBytes, err := copyBody(res.Body)
-	if err != nil {
-		return "", err
-	}
-	res.Body = body
-
-	return string(bodyBytes), nil
-}
-
-type DoWithLog struct {
-	client client.HttpRequestDoer
-}
-
-func (d *DoWithLog) Do(req *http.Request) (*http.Response, error) {
-	reqBody, err := copyReqBody(req)
-	if err != nil {
-		return nil, err
-	}
-
-	tflog.Debug(req.Context(), "api req", map[string]interface{}{"method": req.Method, "uri": req.URL.String(), "body": reqBody})
-
-	res, err := d.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	resBody, err := copyResBody(res)
-	if err != nil {
-		return nil, err
-	}
-
-	tflog.Debug(req.Context(), "api res", map[string]interface{}{"status": res.StatusCode, "body": resBody})
-
-	return res, nil
 }
 
 func (p *HumanitecProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
@@ -199,22 +118,13 @@ func (p *HumanitecProvider) Configure(ctx context.Context, req provider.Configur
 		// Not returning early allows the logic to collect all errors.
 	}
 
-	// Example client configuration for data sources and resources
-
-	client, err := client.NewClientWithResponses(host, func(c *client.Client) error {
-		c.Client = &DoWithLog{&http.Client{}}
-		c.RequestEditors = append(c.RequestEditors, func(_ context.Context, req *http.Request) error {
-			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
-			return nil
-		})
-		return nil
-	})
-	if err != nil {
-		resp.Diagnostics.AddError("Unable to create Humanitec client", err.Error())
+	client, diags := NewHumanitecClient(host, token)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	sourcedata := &HumanitecResourceData{
+	sourcedata := &HumanitecData{
 		Client: client,
 		OrgID:  orgID,
 	}

--- a/internal/provider/resource_account_resource.go
+++ b/internal/provider/resource_account_resource.go
@@ -81,7 +81,7 @@ func (r *ResourceAccountResource) Configure(ctx context.Context, req resource.Co
 		return
 	}
 
-	resdata, ok := req.ProviderData.(*HumanitecResourceData)
+	resdata, ok := req.ProviderData.(*HumanitecData)
 
 	if !ok {
 		resp.Diagnostics.AddError(

--- a/internal/provider/resource_definition_resource.go
+++ b/internal/provider/resource_definition_resource.go
@@ -25,8 +25,15 @@ func NewResourceDefinitionResource() resource.Resource {
 
 // ResourceDefinitionResource defines the resource implementation.
 type ResourceDefinitionResource struct {
-	client *client.ClientWithResponses
-	orgId  string
+	data *HumanitecData
+}
+
+func (r *ResourceDefinitionResource) client() *client.ClientWithResponses {
+	return r.data.Client
+}
+
+func (r *ResourceDefinitionResource) orgId() string {
+	return r.data.OrgID
 }
 
 // DefinitionResourceDriverInputsModel describes the resource data model.
@@ -160,7 +167,7 @@ func (r *ResourceDefinitionResource) Configure(ctx context.Context, req resource
 		return
 	}
 
-	resdata, ok := req.ProviderData.(*HumanitecResourceData)
+	data, ok := req.ProviderData.(*HumanitecData)
 
 	if !ok {
 		resp.Diagnostics.AddError(
@@ -171,8 +178,7 @@ func (r *ResourceDefinitionResource) Configure(ctx context.Context, req resource
 		return
 	}
 
-	r.client = resdata.Client
-	r.orgId = resdata.OrgID
+	r.data = data
 }
 
 func parseOptionalString(input *string) types.String {
@@ -406,40 +412,6 @@ func driverInputsFromModel(ctx context.Context, driver *client.DriverDefinitionR
 	return driverInputs, diags
 }
 
-func (r *ResourceDefinitionResource) driverByDriverType(ctx context.Context, driverType string) (*client.DriverDefinitionResponse, diag.Diagnostics) {
-	var diags diag.Diagnostics
-
-	httpResp, err := r.client.GetOrgsOrgIdResourcesDriversWithResponse(ctx, r.orgId)
-	if err != nil {
-		diags.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to get resource drivers, got error: %s", err))
-		return nil, diags
-	}
-
-	if httpResp.StatusCode() != 200 {
-		diags.AddError(HUM_API_ERR, fmt.Sprintf("Unable to get resource drivers, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
-		return nil, diags
-	}
-
-	if httpResp.JSON200 == nil {
-		diags.AddError(HUM_API_ERR, fmt.Sprintf("Unable to get resource drivers, missing body, body: %s", httpResp.Body))
-		return nil, diags
-	}
-
-	driversByType := map[string]*client.DriverDefinitionResponse{}
-	for _, d := range *httpResp.JSON200 {
-		d := d
-		driversByType[fmt.Sprintf("%s/%s", d.OrgId, d.Id)] = &d
-	}
-
-	driver, ok := driversByType[driverType]
-	if !ok {
-		diags.AddError(HUM_INPUT_ERR, fmt.Sprintf("Not resource driver found for type: %s", driverType))
-		return nil, diags
-	}
-
-	return driver, diags
-}
-
 func (r *ResourceDefinitionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data *DefinitionResourceModel
 
@@ -452,7 +424,7 @@ func (r *ResourceDefinitionResource) Create(ctx context.Context, req resource.Cr
 
 	criteria := criteriaFromModel(data)
 	driverType := data.DriverType.ValueString()
-	driver, diag := r.driverByDriverType(ctx, driverType)
+	driver, diag := r.data.DriverByDriverType(ctx, driverType)
 	resp.Diagnostics.Append(diag...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -464,7 +436,7 @@ func (r *ResourceDefinitionResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	httpResp, err := r.client.PostOrgsOrgIdResourcesDefsWithResponse(ctx, r.orgId, client.PostOrgsOrgIdResourcesDefsJSONRequestBody{
+	httpResp, err := r.client().PostOrgsOrgIdResourcesDefsWithResponse(ctx, r.orgId(), client.PostOrgsOrgIdResourcesDefsJSONRequestBody{
 		Criteria:      criteria,
 		DriverAccount: optionalStringFromModel(data.DriverAccount),
 		DriverInputs:  driverInputs,
@@ -502,7 +474,7 @@ func (r *ResourceDefinitionResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	httpResp, err := r.client.GetOrgsOrgIdResourcesDefsDefIdWithResponse(ctx, r.orgId, data.ID.ValueString())
+	httpResp, err := r.client().GetOrgsOrgIdResourcesDefsDefIdWithResponse(ctx, r.orgId(), data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read resource definition, got error: %s", err))
 		return
@@ -513,7 +485,7 @@ func (r *ResourceDefinitionResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	driver, diag := r.driverByDriverType(ctx, *httpResp.JSON200.DriverType)
+	driver, diag := r.data.DriverByDriverType(ctx, *httpResp.JSON200.DriverType)
 	resp.Diagnostics.Append(diag...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -587,7 +559,7 @@ func (r *ResourceDefinitionResource) Update(ctx context.Context, req resource.Up
 
 	name := data.Name.ValueString()
 	driverType := data.DriverType.ValueString()
-	driver, diag := r.driverByDriverType(ctx, driverType)
+	driver, diag := r.data.DriverByDriverType(ctx, driverType)
 	resp.Diagnostics.Append(diag...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -604,7 +576,7 @@ func (r *ResourceDefinitionResource) Update(ctx context.Context, req resource.Up
 
 	// Add criteria
 	for _, c := range addedCriteria {
-		httpResp, err := r.client.PostOrgsOrgIdResourcesDefsDefIdCriteriaWithResponse(ctx, r.orgId, defID, client.PostOrgsOrgIdResourcesDefsDefIdCriteriaJSONRequestBody{
+		httpResp, err := r.client().PostOrgsOrgIdResourcesDefsDefIdCriteriaWithResponse(ctx, r.orgId(), defID, client.PostOrgsOrgIdResourcesDefsDefIdCriteriaJSONRequestBody{
 			AppId:   optionalStringFromModel(c.AppID),
 			EnvId:   optionalStringFromModel(c.EnvID),
 			EnvType: optionalStringFromModel(c.EnvType),
@@ -630,7 +602,7 @@ func (r *ResourceDefinitionResource) Update(ctx context.Context, req resource.Up
 			continue
 		}
 
-		httpResp, err := r.client.DeleteOrgsOrgIdResourcesDefsDefIdCriteriaCriteriaIdWithResponse(ctx, r.orgId, defID, criteriaID, &client.DeleteOrgsOrgIdResourcesDefsDefIdCriteriaCriteriaIdParams{
+		httpResp, err := r.client().DeleteOrgsOrgIdResourcesDefsDefIdCriteriaCriteriaIdWithResponse(ctx, r.orgId(), defID, criteriaID, &client.DeleteOrgsOrgIdResourcesDefsDefIdCriteriaCriteriaIdParams{
 			Force: &force,
 		})
 		if err != nil {
@@ -644,7 +616,7 @@ func (r *ResourceDefinitionResource) Update(ctx context.Context, req resource.Up
 		}
 	}
 
-	httpResp, err := r.client.PatchOrgsOrgIdResourcesDefsDefIdWithResponse(ctx, r.orgId, defID, client.PatchOrgsOrgIdResourcesDefsDefIdJSONRequestBody{
+	httpResp, err := r.client().PatchOrgsOrgIdResourcesDefsDefIdWithResponse(ctx, r.orgId(), defID, client.PatchOrgsOrgIdResourcesDefsDefIdJSONRequestBody{
 		DriverAccount: optionalStringFromModel(data.DriverAccount),
 		DriverInputs:  driverInputs,
 		Name:          &name,
@@ -679,7 +651,7 @@ func (r *ResourceDefinitionResource) Delete(ctx context.Context, req resource.De
 	}
 
 	force := false
-	httpResp, err := r.client.DeleteOrgsOrgIdResourcesDefsDefIdWithResponse(ctx, r.orgId, data.ID.ValueString(), &client.DeleteOrgsOrgIdResourcesDefsDefIdParams{
+	httpResp, err := r.client().DeleteOrgsOrgIdResourcesDefsDefIdWithResponse(ctx, r.orgId(), data.ID.ValueString(), &client.DeleteOrgsOrgIdResourcesDefsDefIdParams{
 		Force: &force,
 	})
 	if err != nil {

--- a/internal/provider/resource_definition_resource_test.go
+++ b/internal/provider/resource_definition_resource_test.go
@@ -62,6 +62,20 @@ func TestAccResourceDefinition(t *testing.T) {
 			},
 			resourceAttrNameUpdateValue2: "test-2",
 		},
+		{
+			name: "DNS",
+			configCreate: func() string {
+				return testAccResourceDefinitionDNSStaticResource("test-1")
+			},
+			resourceAttrNameIDValue:      "dns-test",
+			resourceAttrNameUpdateKey:    "driver_inputs.values.host",
+			resourceAttrNameUpdateValue1: "test-1",
+			resourceAttrName:             "humanitec_resource_definition.dns_test",
+			configUpdate: func() string {
+				return testAccResourceDefinitionDNSStaticResource("test-2")
+			},
+			resourceAttrNameUpdateValue2: "test-2",
+		},
 	}
 
 	for _, tc := range tests {
@@ -161,6 +175,23 @@ resource "humanitec_resource_definition" "gke_test" {
   }
 }
 `, name)
+}
+
+func testAccResourceDefinitionDNSStaticResource(host string) string {
+	return fmt.Sprintf(`
+resource "humanitec_resource_definition" "dns_test" {
+  id          = "dns-test"
+  name        = "dns-test"
+  type        = "dns"
+  driver_type = "humanitec/static"
+
+  driver_inputs = {
+    values = {
+      host = "%s"
+    }
+  }
+}
+`, host)
 }
 
 func TestAccResourceDefinitionWithDefinition(t *testing.T) {


### PR DESCRIPTION
Support the static driver, which has no dedicated input schema and instead re-assembles the resource type output schema. 

Additionally fetch resource drivers & types only once per execution.