### PR TITLE
fix: use PUT to update resources

### DIFF
--- a/internal/provider/resource_definition_resource.go
+++ b/internal/provider/resource_definition_resource.go
@@ -628,10 +628,10 @@ func (r *ResourceDefinitionResource) Update(ctx context.Context, req resource.Up
 		}
 	}
 
-	httpResp, err := r.client().PatchOrgsOrgIdResourcesDefsDefIdWithResponse(ctx, r.orgId(), defID, client.PatchOrgsOrgIdResourcesDefsDefIdJSONRequestBody{
+	httpResp, err := r.client().PutOrgsOrgIdResourcesDefsDefIdWithResponse(ctx, r.orgId(), defID, client.PutOrgsOrgIdResourcesDefsDefIdJSONRequestBody{
 		DriverAccount: optionalStringFromModel(data.DriverAccount),
 		DriverInputs:  driverInputs,
-		Name:          &name,
+		Name:          name,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read definition, got error: %s", err))


### PR DESCRIPTION
The PATCH endpoint is merging the provided inputs with the existing inputs, which isn't something we want here.

Use the newly added PUT method instead of to ensure the tf state matches the state in Humanitec.