### PR TITLE
Remove halt state for App and Resource definition when removed outside Terraform

### DIFF
--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -137,8 +137,7 @@ func (r *ResourceApplication) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	//this code should be 404, bug in the API
-	if httpResp.StatusCode() == 403 {
+	if httpResp.StatusCode() == 404 {
 		resp.Diagnostics.AddWarning("Application not found", fmt.Sprintf("The app (%s) was deleted outside Terraform", data.ID.ValueString()))
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -139,7 +139,7 @@ func (r *ResourceApplication) Read(ctx context.Context, req resource.ReadRequest
 
 	//this code should be 404, bug in the API
 	if httpResp.StatusCode() == 403 {
-		resp.Diagnostics.AddWarning("Application already removed", fmt.Sprintf("The app (%s) was deleted outisde Terraform, recreating", data.ID.ValueString()))
+		resp.Diagnostics.AddWarning("Application already removed", fmt.Sprintf("The app (%s) was deleted outisde Terraform", data.ID.ValueString()))
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -139,7 +139,7 @@ func (r *ResourceApplication) Read(ctx context.Context, req resource.ReadRequest
 
 	//this code should be 404, bug in the API
 	if httpResp.StatusCode() == 403 {
-		resp.Diagnostics.AddWarning("Application not found", fmt.Sprintf("The app (%s) was deleted outisde Terraform", data.ID.ValueString()))
+		resp.Diagnostics.AddWarning("Application not found", fmt.Sprintf("The app (%s) was deleted outside Terraform", data.ID.ValueString()))
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -139,7 +139,7 @@ func (r *ResourceApplication) Read(ctx context.Context, req resource.ReadRequest
 
 	//this code should be 404, bug in the API
 	if httpResp.StatusCode() == 403 {
-		resp.Diagnostics.AddWarning("Application already removed", fmt.Sprintf("The app (%s) was deleted outisde Terraform", data.ID.ValueString()))
+		resp.Diagnostics.AddWarning("Application not found", fmt.Sprintf("The app (%s) was deleted outisde Terraform", data.ID.ValueString()))
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -137,6 +137,13 @@ func (r *ResourceApplication) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	//this code should be 404, bug in the API
+	if httpResp.StatusCode() == 403 {
+		resp.Diagnostics.AddWarning("Application already removed", fmt.Sprintf("The app (%s) was deleted outisde Terraform, recreating", data.ID.ValueString()))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to read application, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/resource_definition_resource.go
+++ b/internal/provider/resource_definition_resource.go
@@ -510,7 +510,7 @@ func (r *ResourceDefinitionResource) Read(ctx context.Context, req resource.Read
 	}
 
 	if httpResp.StatusCode() == 404 {
-		resp.Diagnostics.AddWarning("Resource definition already removed", fmt.Sprintf("The resource definition (%s) was deleted outisde Terraform", data.ID.ValueString()))
+		resp.Diagnostics.AddWarning("Resource definition not found", fmt.Sprintf("The resource definition (%s) was deleted outisde Terraform", data.ID.ValueString()))
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_definition_resource.go
+++ b/internal/provider/resource_definition_resource.go
@@ -510,7 +510,7 @@ func (r *ResourceDefinitionResource) Read(ctx context.Context, req resource.Read
 	}
 
 	if httpResp.StatusCode() == 404 {
-		resp.Diagnostics.AddWarning("Resource definition already removed", fmt.Sprintf("The resource definition (%s) was deleted outisde Terraform, recreating", data.ID.ValueString()))
+		resp.Diagnostics.AddWarning("Resource definition already removed", fmt.Sprintf("The resource definition (%s) was deleted outisde Terraform", data.ID.ValueString()))
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_definition_resource.go
+++ b/internal/provider/resource_definition_resource.go
@@ -509,6 +509,12 @@ func (r *ResourceDefinitionResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
+	if httpResp.StatusCode() == 404 {
+		resp.Diagnostics.AddWarning("Resource definition already removed", fmt.Sprintf("The resource definition (%s) was deleted outisde Terraform, recreating", data.ID.ValueString()))
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	if httpResp.StatusCode() != 200 {
 		resp.Diagnostics.AddError(HUM_API_ERR, fmt.Sprintf("Unable to read resource definition, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 		return

--- a/internal/provider/resource_definition_resource.go
+++ b/internal/provider/resource_definition_resource.go
@@ -510,7 +510,7 @@ func (r *ResourceDefinitionResource) Read(ctx context.Context, req resource.Read
 	}
 
 	if httpResp.StatusCode() == 404 {
-		resp.Diagnostics.AddWarning("Resource definition not found", fmt.Sprintf("The resource definition (%s) was deleted outisde Terraform", data.ID.ValueString()))
+		resp.Diagnostics.AddWarning("Resource definition not found", fmt.Sprintf("The resource definition (%s) was deleted outside Terraform", data.ID.ValueString()))
 		resp.State.RemoveResource(ctx)
 		return
 	}


### PR DESCRIPTION
If a resource is removed using the UI (or API), currently the provider treat this as a terminal error.

For convenience, I propose to just remove the state instead of forcing people to run `terraform state rm ...`

The official AWS Terraform provider has the same behaviour  (example: https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/s3/bucket.go#L959) so it's a known way to manage the state when things are removed outside Terraform.

Tests: I am not sure how you'd like to modify the test suite to integrate this external call to delete the resources, so let me know how you wish to proceed.

Tested Manually:
- Create Res def. and App, and then remove manually:

- Run Apply:
  - Expected: Recreate
  - Actual: Recreate
- Run Destroy: 
  - Expected: Nothing
  - Actual: Nothing
- Run Apply with changes: 
  - Expected: Recreate or Replace
  - Actual: Recreate or Replace

The API for App returns 403 instead of 404, a bug was filed for the same.

I don't foresee any side effects, but let discuss!