### PR TITLE
WAL-6866: Terraform Provider documentation mentions "Modules" instead of "Workloads"

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -3,12 +3,12 @@
 page_title: "humanitec_application Resource - terraform-provider-humanitec"
 subcategory: ""
 description: |-
-  An Application is a collection of Modules that work together. When deployed, all Modules in an Application are deployed to the same namespace.
+  An Application is a collection of Workloads that work together. When deployed, all Workloads in an Application are deployed to the same namespace.
 ---
 
 # humanitec_application (Resource)
 
-An Application is a collection of Modules that work together. When deployed, all Modules in an Application are deployed to the same namespace.
+An Application is a collection of Workloads that work together. When deployed, all Workloads in an Application are deployed to the same namespace.
 
 ## Example Usage
 

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -59,7 +59,7 @@ func (r *ResourceApplication) Metadata(ctx context.Context, req resource.Metadat
 
 func (r *ResourceApplication) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "An Application is a collection of Modules that work together. When deployed, all Modules in an Application are deployed to the same namespace.",
+		MarkdownDescription: "An Application is a collection of Workloads that work together. When deployed, all Workloads in an Application are deployed to the same namespace.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{


### PR DESCRIPTION
Fixing references to old nomenclature.