### PR TITLE
fix: updating force delete resource criteria

### DIFF
--- a/internal/provider/resource_definition_criteria_resource.go
+++ b/internal/provider/resource_definition_criteria_resource.go
@@ -247,7 +247,15 @@ func (r *ResourceDefinitionCriteriaResource) Read(ctx context.Context, req resou
 }
 
 func (r *ResourceDefinitionCriteriaResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	resp.Diagnostics.AddError("UNSUPPORTED_OPERATION", "Updating an ResourceDefinitionCriteria is currently not supported")
+	var data *ResourceDefinitionCriteriaResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	// All attributes require a replacement, so no API calls here
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *ResourceDefinitionCriteriaResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
Otherwise changing the `force_delete` attribute caused:

```
╷
│ Error: UNSUPPORTED_OPERATION
│
│   with humanitec_resource_definition_criteria...
│
│ Updating an ResourceDefinitionCriteria is currently not supported
╵
```