### PR TITLE
fix: mark resource account credentials as sensitive

### DIFF
--- a/docs/resources/resource_account.md
+++ b/docs/resources/resource_account.md
@@ -26,7 +26,7 @@ resource "humanitec_resource_account" "gcp_test" {
 
 ### Required
 
-- `credentials` (String) Credentials associated with the account.
+- `credentials` (String, Sensitive) Credentials associated with the account.
 - `id` (String) Unique identifier for the account (in scope of the organization it belongs to).
 - `name` (String) Display name.
 - `type` (String) The type of the account

--- a/internal/provider/resource_account_resource.go
+++ b/internal/provider/resource_account_resource.go
@@ -75,6 +75,7 @@ func (r *ResourceAccountResource) Schema(ctx context.Context, req resource.Schem
 			"credentials": schema.StringAttribute{
 				MarkdownDescription: "Credentials associated with the account.",
 				Required:            true,
+				Sensitive:           true,
 			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Delete: true,

--- a/internal/provider/resource_definition_resource_test.go
+++ b/internal/provider/resource_definition_resource_test.go
@@ -250,7 +250,6 @@ resource "humanitec_resource_definition" "ingress_test" {
       labels = jsonencode({
 				name = "%s"
 			})
-      api_version = "v1"
 			no_tls      = true
     }
   }


### PR DESCRIPTION
Those credentials usually contain sensitive values.