### PR TITLE
feat: support json inputs for resource definitions

### DIFF
--- a/docs/resources/resource_definition.md
+++ b/docs/resources/resource_definition.md
@@ -20,9 +20,9 @@ resource "humanitec_resource_definition" "s3" {
 
   driver_type = "humanitec/s3"
   driver_inputs = {
-    values = {
+    values_string = jsonencode({
       region = "us-east-1"
-    }
+    })
   }
 }
 
@@ -33,16 +33,16 @@ resource "humanitec_resource_definition" "postgres" {
   driver_type = "humanitec/postgres-cloudsql-static"
 
   driver_inputs = {
-    values = {
+    values_string = jsonencode({
       "instance" = "test:test:test"
       "name"     = "db-dev"
       "host"     = "127.0.0.1"
       "port"     = "5432"
-    }
-    secrets = {
+    })
+    secrets_string = jsonencode({
       "username" = "test"
       "password" = "test"
-    }
+    })
   }
 
   criteria = [
@@ -59,15 +59,15 @@ resource "humanitec_resource_definition" "gke" {
   driver_type = "humanitec/k8s-cluster-gke"
 
   driver_inputs = {
-    values = {
+    values_string = jsonencode({
       "loadbalancer" = "1.1.1.1"
       "name"         = "gke-dev"
       "project_id"   = "test"
       "zone"         = "europe-west3"
-    }
-    secrets = {
+    })
+    secrets_string = jsonencode({
       "credentials" = "{}"
-    }
+    })
   }
 
   criteria = [
@@ -122,8 +122,10 @@ Read-Only:
 
 Optional:
 
-- `secrets` (Map of String, Sensitive) Secrets section of the data set.
-- `values` (Map of String) Values section of the data set. Passed around as-is.
+- `secrets` (Map of String, Sensitive, Deprecated) Secrets section of the data set. Deprecated in favour of secrets_string.
+- `secrets_string` (String) JSON encoded secret data set. Passed around as-is.
+- `values` (Map of String, Deprecated) Values section of the data set. Passed around as-is. Deprecated in favour of values_string.
+- `values_string` (String) JSON encoded input data set. Passed around as-is.
 
 
 <a id="nestedatt--provision"></a>

--- a/examples/resources/humanitec_resource_definition/resource.tf
+++ b/examples/resources/humanitec_resource_definition/resource.tf
@@ -5,9 +5,9 @@ resource "humanitec_resource_definition" "s3" {
 
   driver_type = "humanitec/s3"
   driver_inputs = {
-    values = {
+    values_string = jsonencode({
       region = "us-east-1"
-    }
+    })
   }
 }
 
@@ -18,16 +18,16 @@ resource "humanitec_resource_definition" "postgres" {
   driver_type = "humanitec/postgres-cloudsql-static"
 
   driver_inputs = {
-    values = {
+    values_string = jsonencode({
       "instance" = "test:test:test"
       "name"     = "db-dev"
       "host"     = "127.0.0.1"
       "port"     = "5432"
-    }
-    secrets = {
+    })
+    secrets_string = jsonencode({
       "username" = "test"
       "password" = "test"
-    }
+    })
   }
 
   criteria = [
@@ -44,15 +44,15 @@ resource "humanitec_resource_definition" "gke" {
   driver_type = "humanitec/k8s-cluster-gke"
 
   driver_inputs = {
-    values = {
+    values_string = jsonencode({
       "loadbalancer" = "1.1.1.1"
       "name"         = "gke-dev"
       "project_id"   = "test"
       "zone"         = "europe-west3"
-    }
-    secrets = {
+    })
+    secrets_string = jsonencode({
       "credentials" = "{}"
-    }
+    })
   }
 
   criteria = [

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,9 @@ go 1.20
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
-	github.com/hashicorp/terraform-plugin-framework v1.3.2
+	github.com/hashicorp/terraform-plugin-framework v1.3.3
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1
+	github.com/hashicorp/terraform-plugin-framework-validators v0.11.0
 	github.com/hashicorp/terraform-plugin-go v0.18.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0

--- a/go.sum
+++ b/go.sum
@@ -112,10 +112,12 @@ github.com/hashicorp/terraform-json v0.17.1 h1:eMfvh/uWggKmY7Pmb3T85u86E2EQg6EQH
 github.com/hashicorp/terraform-json v0.17.1/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
 github.com/hashicorp/terraform-plugin-docs v0.16.0 h1:UmxFr3AScl6Wged84jndJIfFccGyBZn52KtMNsS12dI=
 github.com/hashicorp/terraform-plugin-docs v0.16.0/go.mod h1:M3ZrlKBJAbPMtNOPwHicGi1c+hZUh7/g0ifT/z7TVfA=
-github.com/hashicorp/terraform-plugin-framework v1.3.2 h1:aQ6GSD0CTnvoALEWvKAkcH/d8jqSE0Qq56NYEhCexUs=
-github.com/hashicorp/terraform-plugin-framework v1.3.2/go.mod h1:oimsRAPJOYkZ4kY6xIGfR0PHjpHLDLaknzuptl6AvnY=
+github.com/hashicorp/terraform-plugin-framework v1.3.3 h1:D18BlA8gdV4+W8WKhUqxudiYomPZHv94FFzyoSCKC8Q=
+github.com/hashicorp/terraform-plugin-framework v1.3.3/go.mod h1:2gGDpWiTI0irr9NSTLFAKlTi6KwGti3AoU19rFqU30o=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1 h1:gm5b1kHgFFhaKFhm4h2TgvMUlNzFAtUqlcOWnWPm+9E=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1/go.mod h1:MsjL1sQ9L7wGwzJ5RjcI6FzEMdyoBnw+XK8ZnOvQOLY=
+github.com/hashicorp/terraform-plugin-framework-validators v0.11.0 h1:DKb1bX7/EPZUTW6F5zdwJzS/EZ/ycVD6JAW5RYOj4f8=
+github.com/hashicorp/terraform-plugin-framework-validators v0.11.0/go.mod h1:dzxOiHh7O9CAwc6p8N4mR1H++LtRkl+u+21YNiBVNno=
 github.com/hashicorp/terraform-plugin-go v0.18.0 h1:IwTkOS9cOW1ehLd/rG0y+u/TGLK9y6fGoBjXVUquzpE=
 github.com/hashicorp/terraform-plugin-go v0.18.0/go.mod h1:l7VK+2u5Kf2y+A+742GX0ouLut3gttudmvMgN0PA74Y=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/provider/resource_definition_resource_test.go
+++ b/internal/provider/resource_definition_resource_test.go
@@ -27,13 +27,13 @@ func TestAccResourceDefinition(t *testing.T) {
 				return testAccResourceDefinitionS3Resource("us-east-1")
 			},
 			resourceAttrNameIDValue:      "s3-test",
-			resourceAttrNameUpdateKey:    "driver_inputs.values.region",
-			resourceAttrNameUpdateValue1: "us-east-1",
+			resourceAttrNameUpdateKey:    "driver_inputs.values_string",
+			resourceAttrNameUpdateValue1: "{\"region\":\"us-east-1\"}",
 			resourceAttrName:             "humanitec_resource_definition.s3_test",
 			configUpdate: func() string {
 				return testAccResourceDefinitionS3Resource("us-east-2")
 			},
-			resourceAttrNameUpdateValue2: "us-east-2",
+			resourceAttrNameUpdateValue2: "{\"region\":\"us-east-2\"}",
 		},
 		{
 			name: "Postgres",
@@ -41,13 +41,13 @@ func TestAccResourceDefinition(t *testing.T) {
 				return testAccResourceDefinitionPostgresResource("test-1")
 			},
 			resourceAttrNameIDValue:      "postgres-test",
-			resourceAttrNameUpdateKey:    "driver_inputs.values.name",
-			resourceAttrNameUpdateValue1: "test-1",
+			resourceAttrNameUpdateKey:    "driver_inputs.values_string",
+			resourceAttrNameUpdateValue1: "{\"host\":\"127.0.0.1\",\"instance\":\"test:test:test\",\"name\":\"test-1\",\"port\":5432}",
 			resourceAttrName:             "humanitec_resource_definition.postgres_test",
 			configUpdate: func() string {
 				return testAccResourceDefinitionPostgresResource("test-2")
 			},
-			resourceAttrNameUpdateValue2: "test-2",
+			resourceAttrNameUpdateValue2: "{\"host\":\"127.0.0.1\",\"instance\":\"test:test:test\",\"name\":\"test-2\",\"port\":5432}",
 		},
 		{
 			name: "GKE",
@@ -55,13 +55,13 @@ func TestAccResourceDefinition(t *testing.T) {
 				return testAccResourceDefinitionGKEResource("test-1")
 			},
 			resourceAttrNameIDValue:      "gke-test",
-			resourceAttrNameUpdateKey:    "driver_inputs.values.name",
-			resourceAttrNameUpdateValue1: "test-1",
+			resourceAttrNameUpdateKey:    "driver_inputs.values_string",
+			resourceAttrNameUpdateValue1: "{\"loadbalancer\":\"1.1.1.1\",\"name\":\"test-1\",\"project_id\":\"test\",\"zone\":\"europe-west3\"}",
 			resourceAttrName:             "humanitec_resource_definition.gke_test",
 			configUpdate: func() string {
 				return testAccResourceDefinitionGKEResource("test-2")
 			},
-			resourceAttrNameUpdateValue2: "test-2",
+			resourceAttrNameUpdateValue2: "{\"loadbalancer\":\"1.1.1.1\",\"name\":\"test-2\",\"project_id\":\"test\",\"zone\":\"europe-west3\"}",
 		},
 		{
 			name: "DNS",
@@ -69,13 +69,13 @@ func TestAccResourceDefinition(t *testing.T) {
 				return testAccResourceDefinitionDNSStaticResource("test-1")
 			},
 			resourceAttrNameIDValue:      "dns-test",
-			resourceAttrNameUpdateKey:    "driver_inputs.values.host",
-			resourceAttrNameUpdateValue1: "test-1",
+			resourceAttrNameUpdateKey:    "driver_inputs.values_string",
+			resourceAttrNameUpdateValue1: "{\"host\":\"test-1\"}",
 			resourceAttrName:             "humanitec_resource_definition.dns_test",
 			configUpdate: func() string {
 				return testAccResourceDefinitionDNSStaticResource("test-2")
 			},
-			resourceAttrNameUpdateValue2: "test-2",
+			resourceAttrNameUpdateValue2: "{\"host\":\"test-2\"}",
 		},
 		{
 			name: "Ingress",
@@ -83,13 +83,13 @@ func TestAccResourceDefinition(t *testing.T) {
 				return testAccResourceDefinitionIngressResource("test-1")
 			},
 			resourceAttrNameIDValue:      "ingress-test",
-			resourceAttrNameUpdateKey:    "driver_inputs.values.labels",
-			resourceAttrNameUpdateValue1: "{\"name\":\"test-1\"}",
+			resourceAttrNameUpdateKey:    "driver_inputs.values_string",
+			resourceAttrNameUpdateValue1: "{\"labels\":{\"name\":\"test-1\"},\"no_tls\":true}",
 			resourceAttrName:             "humanitec_resource_definition.ingress_test",
 			configUpdate: func() string {
 				return testAccResourceDefinitionIngressResource("test-2")
 			},
-			resourceAttrNameUpdateValue2: "{\"name\":\"test-2\"}",
+			resourceAttrNameUpdateValue2: "{\"labels\":{\"name\":\"test-2\"},\"no_tls\":true}",
 		},
 		{
 			name: "Provision",
@@ -165,9 +165,9 @@ resource "humanitec_resource_definition" "s3_test" {
   driver_type = "humanitec/s3"
 
   driver_inputs = {
-    values = {
+    values_string = jsonencode({
       "region" = "%s"
-    }
+    })
   }
 }
 `, region)
@@ -182,16 +182,16 @@ resource "humanitec_resource_definition" "postgres_test" {
   driver_type = "humanitec/postgres-cloudsql-static"
 
   driver_inputs = {
-    values = {
+    values_string = jsonencode({
       "instance" = "test:test:test"
       "name" = "%s"
       "host" = "127.0.0.1"
-      "port" = "5432"
-    }
-    secrets = {
+      "port" = 5432
+    })
+    secrets_string = jsonencode({
       "username" = "test"
       "password" = "test"
-    }
+    })
   }
 }
 `, name)
@@ -206,15 +206,15 @@ resource "humanitec_resource_definition" "gke_test" {
   driver_type = "humanitec/k8s-cluster-gke"
 
   driver_inputs = {
-    values = {
+    values_string = jsonencode({
       "loadbalancer" = "1.1.1.1"
       "name" = "%s"
       "project_id" = "test"
       "zone" = "europe-west3"
-    }
-    secrets = {
-      "credentials" = "{}"
-    }
+		})
+    secrets_string = jsonencode({
+      "credentials" = {}
+    })
   }
 }
 `, name)
@@ -229,9 +229,9 @@ resource "humanitec_resource_definition" "dns_test" {
   driver_type = "humanitec/static"
 
   driver_inputs = {
-    values = {
+    values_string = jsonencode({
       host = "%s"
-    }
+    })
   }
 }
 `, host)
@@ -246,12 +246,12 @@ resource "humanitec_resource_definition" "ingress_test" {
   driver_type = "humanitec/ingress"
 
   driver_inputs = {
-    values = {
-      labels = jsonencode({
+    values_string = jsonencode({
+      labels = {
 				name = "%s"
-			})
+			}
 			no_tls      = true
-    }
+    })
   }
 }
 `, host)
@@ -283,12 +283,61 @@ resource "humanitec_resource_definition" "provision_test" {
 	}
 
 	driver_inputs = {
-		values = {
+		values_string = jsonencode({
 			"region" = "us-east-1"
-		}
+		})
 	}
 }
 `, matchDependents)
+}
+
+func TestAccResourceDefinitionLegacyValues(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccResourceDefinitionS3ResourceLegacy("us-east-1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("humanitec_resource_definition.s3_legacy_test", "id", "s3-legacy-test"),
+					resource.TestCheckResourceAttr("humanitec_resource_definition.s3_legacy_test", "driver_inputs.values.region", "us-east-1"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:            "humanitec_resource_definition.s3_legacy_test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"driver_inputs.secrets", "driver_inputs.values", "force_delete"},
+			},
+			// Update and Read testing
+			{
+				Config: testAccResourceDefinitionS3ResourceLegacy("us-east-2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("humanitec_resource_definition.s3_legacy_test", "driver_inputs.values.region", "us-east-2"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccResourceDefinitionS3ResourceLegacy(region string) string {
+	return fmt.Sprintf(`
+resource "humanitec_resource_definition" "s3_legacy_test" {
+  id          = "s3-legacy-test"
+  name        = "s3-legacy-test"
+  type        = "s3"
+  driver_type = "humanitec/s3"
+
+  driver_inputs = {
+    values = {
+      "region" = "%s"
+    }
+  }
+}
+`, region)
 }
 
 func TestAccResourceDefinitionWithDefinition(t *testing.T) {
@@ -350,9 +399,9 @@ resource "humanitec_resource_definition" "s3_test" {
   driver_type = "humanitec/s3"
 
   driver_inputs = {
-    values = {
+		values_string = jsonencode({
       "region" = "us-east-1"
-    }
+    })
   }
 
 	criteria = [%s]


### PR DESCRIPTION
Support json input for resource definition values and secrets, which no longer requires type casting base on the driver schema and therefor allows also attributes not defined in the schema.