### PR TITLE
fix: remove active resource deletion

### DIFF
--- a/internal/provider/resource_definition_criteria_resource.go
+++ b/internal/provider/resource_definition_criteria_resource.go
@@ -25,7 +25,7 @@ import (
 var _ resource.Resource = &ResourceDefinitionCriteriaResource{}
 var _ resource.ResourceWithImportState = &ResourceDefinitionCriteriaResource{}
 
-var defaultResourceDefinitionCriteriaDeleteTimeout = 3 * time.Minute
+var defaultResourceDefinitionCriteriaDeleteTimeout = 10 * time.Minute
 
 func NewResourceDefinitionCriteriaResource() resource.Resource {
 	return &ResourceDefinitionCriteriaResource{}

--- a/internal/provider/resource_definition_resource.go
+++ b/internal/provider/resource_definition_resource.go
@@ -29,7 +29,7 @@ import (
 var _ resource.Resource = &ResourceDefinitionResource{}
 var _ resource.ResourceWithImportState = &ResourceDefinitionResource{}
 
-var defaultResourceDefinitionDeleteTimeout = 3 * time.Minute
+var defaultResourceDefinitionDeleteTimeout = 10 * time.Minute
 
 func NewResourceDefinitionResource() resource.Resource {
 	return &ResourceDefinitionResource{}


### PR DESCRIPTION
The Humanitec resource cleanup logic improved and there is no longer a need to explicitly remove active resources.

As resource deletion now happens after the app deletion, I've increased the deletion timeout for res def / res def criteria to ensure deleting an app and matched res def still works as expected.