### PR TITLE
Replace HUMANITEC_ORG_ID with HUMANITEC_ORG

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
           terraform_wrapper: false
       - run: make testacc
         env:
-          HUMANITEC_ORG_ID: ${{ secrets.HUMANITEC_ORG_ID }}
+          HUMANITEC_ORG: ${{ secrets.HUMANITEC_ORG_ID }} # Reusing env variable on GitHub Actions
           HUMANITEC_TOKEN: ${{ secrets.HUMANITEC_TOKEN }}
   unit:
     name: Unit Tests

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,5 +25,5 @@ provider "humanitec" {
 
 - `disable_ssl_certificate_verification` (Boolean) Disables SSL certificate verification
 - `host` (String) Humanitec API host (or using the `HUMANITEC_HOST` environment variable)
-- `org_id` (String) Humanitec Organization ID (or using the `HUMANITEC_ORG_ID` environment variable)
+- `org_id` (String) Humanitec Organization ID (or using the `HUMANITEC_ORG` environment variable)
 - `token` (String, Sensitive) Humanitec Token (or using the `HUMANITEC_TOKEN` environment variable)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -56,7 +56,7 @@ func (p *HumanitecProvider) Schema(ctx context.Context, req provider.SchemaReque
 				Optional:            true,
 			},
 			"org_id": schema.StringAttribute{
-				MarkdownDescription: "Humanitec Organization ID (or using the `HUMANITEC_ORG_ID` environment variable)",
+				MarkdownDescription: "Humanitec Organization ID (or using the `HUMANITEC_ORG` environment variable)",
 				Optional:            true,
 			},
 			"token": schema.StringAttribute{
@@ -79,7 +79,16 @@ func (p *HumanitecProvider) Configure(ctx context.Context, req provider.Configur
 		host = humanitec.DefaultAPIHost
 	}
 
-	orgID := os.Getenv("HUMANITEC_ORG_ID")
+	orgID := os.Getenv("HUMANITEC_ORG")
+	if orgID == "" {
+		if orgIDOld := os.Getenv("HUMANITEC_ORG_ID"); orgIDOld != "" {
+			orgID = orgIDOld
+			resp.Diagnostics.AddWarning(
+				"Environment variable HUMANITEC_ORG_ID has been deprecated",
+				"Environment variable HUMANITEC_ORG_ID has been deprecated "+
+					"please use HUMANITEC_ORG instead to set your org_id to the terraform driver ")
+		}
+	}
 	token := os.Getenv("HUMANITEC_TOKEN")
 
 	var data HumanitecProviderModel
@@ -116,7 +125,7 @@ func (p *HumanitecProvider) Configure(ctx context.Context, req provider.Configur
 		resp.Diagnostics.AddError(
 			"Missing API Org ID Configuration",
 			"While configuring the provider, the API token was not found in "+
-				"the HUMANITEC_ORG_ID environment variable or provider "+
+				"the HUMANITEC_ORG environment variable or provider "+
 				"configuration block org_id attribute.",
 		)
 		// Not returning early allows the logic to collect all errors.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -17,7 +17,7 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 }
 
 func testAccPreCheck(t *testing.T) {
-	checkEnvVar(t, "HUMANITEC_ORG_ID")
+	checkEnvVar(t, "HUMANITEC_ORG")
 	checkEnvVar(t, "HUMANITEC_TOKEN")
 }
 

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -44,7 +44,7 @@ func TestAccResourceApplicationDeletedOutManually(t *testing.T) {
 	ctx := context.Background()
 	id := fmt.Sprintf("test-%d", time.Now().UnixNano())
 
-	orgID := os.Getenv("HUMANITEC_ORG_ID")
+	orgID := os.Getenv("HUMANITEC_ORG")
 	token := os.Getenv("HUMANITEC_TOKEN")
 
 	var client *humanitec.Client

--- a/internal/provider/resource_definition_resource_test.go
+++ b/internal/provider/resource_definition_resource_test.go
@@ -828,6 +828,6 @@ func TestParseMapInput_UnexpectedType(t *testing.T) {
 }
 
 func getDefinitionSecretPath(defID string) string {
-	orgID := os.Getenv("HUMANITEC_ORG_ID")
+	orgID := os.Getenv("HUMANITEC_ORG")
 	return fmt.Sprintf("orgs/%s/resources/defs/%s/driver_secrets", orgID, defID)
 }

--- a/internal/provider/resource_pipeline.go
+++ b/internal/provider/resource_pipeline.go
@@ -66,12 +66,12 @@ func (r *ResourcePipeline) Schema(ctx context.Context, req resource.SchemaReques
 			},
 			"metadata": schema.MapAttribute{
 				MarkdownDescription: "The map of key value pipeline additional information.",
-				ElementType: types.StringType,
+				ElementType:         types.StringType,
 				Computed:            true,
 			},
 			"trigger_types": schema.SetAttribute{
 				MarkdownDescription: "The list of trigger types in the current schema.",
-				ElementType: types.StringType,
+				ElementType:         types.StringType,
 				Computed:            true,
 			},
 		},

--- a/internal/provider/resource_pipeline_test.go
+++ b/internal/provider/resource_pipeline_test.go
@@ -57,7 +57,7 @@ jobs:
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName:      "humanitec_pipeline.pipeline_test",
+				ResourceName: "humanitec_pipeline.pipeline_test",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					pipeline, err := testResource("humanitec_pipeline.pipeline_test", s)
 					if err != nil {

--- a/internal/provider/resource_registry.go
+++ b/internal/provider/resource_registry.go
@@ -123,17 +123,17 @@ func (r *ResourceRegistry) Configure(ctx context.Context, req resource.Configure
 }
 
 type RegistryModel struct {
-	ID       types.String `tfsdk:"id"`
-	Registry types.String `tfsdk:"registry"`
-	Type     types.String `tfsdk:"type"`
-	EnableCI types.Bool   `tfsdk:"enable_ci"`
-	Creds    types.Object `tfsdk:"creds"`
-	Secrets  *map[string]SecretsModel    `tfsdk:"secrets"`
+	ID       types.String             `tfsdk:"id"`
+	Registry types.String             `tfsdk:"registry"`
+	Type     types.String             `tfsdk:"type"`
+	EnableCI types.Bool               `tfsdk:"enable_ci"`
+	Creds    types.Object             `tfsdk:"creds"`
+	Secrets  *map[string]SecretsModel `tfsdk:"secrets"`
 }
 
 type SecretsModel struct {
 	Namespace types.String `tfsdk:"namespace"`
-	Secret types.String `tfsdk:"secret"`
+	Secret    types.String `tfsdk:"secret"`
 }
 
 func (r *ResourceRegistry) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -374,11 +374,11 @@ func parseRegistryResponse(ctx context.Context, res *client.RegistryResponse, da
 	data.EnableCI = types.BoolValue(res.EnableCi)
 
 	if res.Secrets != nil {
-		secrets :=  make(map[string]SecretsModel)
+		secrets := make(map[string]SecretsModel)
 		for key, value := range *res.Secrets {
 			secrets[key] = SecretsModel{
 				Namespace: types.StringValue(value.Namespace),
-				Secret: types.StringValue(value.Secret),
+				Secret:    types.StringValue(value.Secret),
 			}
 		}
 		data.Secrets = &secrets

--- a/internal/provider/resource_registry_test.go
+++ b/internal/provider/resource_registry_test.go
@@ -28,7 +28,7 @@ func TestAccResourceRegistry(t *testing.T) {
 			// ImportState testing
 			{
 				ResourceName:      "humanitec_registry.registry_test",
-				ImportStateId: id,
+				ImportStateId:     id,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/internal/provider/resource_value_test.go
+++ b/internal/provider/resource_value_test.go
@@ -53,7 +53,7 @@ func TestAccResourceValue(t *testing.T) {
 func TestAccResourceValueWithSecretValue(t *testing.T) {
 	appID := fmt.Sprintf("val-test-app-%d", time.Now().UnixNano())
 	key := "VAL_SECRET_1"
-	orgID := os.Getenv("HUMANITEC_ORG_ID")
+	orgID := os.Getenv("HUMANITEC_ORG")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -97,7 +97,7 @@ func TestAccResourceValueWithSecretValue(t *testing.T) {
 func TestAccResourceValueWithSecretValueSecretRefValue(t *testing.T) {
 	appID := fmt.Sprintf("val-test-app-%d", time.Now().UnixNano())
 	key := "VAL_SECRET_REF_VALUE_1"
-	orgID := os.Getenv("HUMANITEC_ORG_ID")
+	orgID := os.Getenv("HUMANITEC_ORG")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -140,7 +140,7 @@ func TestAccResourceValueWithSecretValueSecretRefValue(t *testing.T) {
 func TestAccResourceValueWithSecretRef(t *testing.T) {
 	appID := fmt.Sprintf("val-test-app-%d", time.Now().UnixNano())
 	key := "VAL_SECRET_REF_1"
-	orgID := os.Getenv("HUMANITEC_ORG_ID")
+	orgID := os.Getenv("HUMANITEC_ORG")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -195,7 +195,7 @@ func TestAccResourceValueDeletedOutManually(t *testing.T) {
 
 	key := "VAL_1"
 
-	orgID := os.Getenv("HUMANITEC_ORG_ID")
+	orgID := os.Getenv("HUMANITEC_ORG")
 	token := os.Getenv("HUMANITEC_TOKEN")
 
 	var client *humanitec.Client


### PR DESCRIPTION
Support `HUMANITEC_ORG` to specific the Humanitec Organization. Mark `HUMANITEC_ORG_ID` as deprecated.