### PR TITLE
fix(application): 404 during delete

### DIFF
--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -255,14 +255,14 @@ func (r *ResourceApplication) Delete(ctx context.Context, req resource.DeleteReq
 			return retry.NonRetryableError(err)
 		}
 
-		if httpResp.StatusCode() != 204 {
-			return retry.RetryableError(fmt.Errorf("unable to delete application, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
+		if httpResp.StatusCode() == 404 || httpResp.StatusCode() == 204 {
+			return nil
 		}
 
-		return nil
+		return retry.RetryableError(fmt.Errorf("unable to delete application, unexpected status code: %d, body: %s", httpResp.StatusCode(), httpResp.Body))
 	})
 	if err != nil {
-		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read application, got error: %s", err))
+		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to delete application, got error: %s", err))
 		return
 	}
 }


### PR DESCRIPTION
Handle a 404 while trying to delete an application, which can occur when the app has been deleted manually.