### PR TITLE
chore: updated humanitec client and update code to use new SDK operation ids

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.20.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
-	github.com/humanitec/humanitec-go-autogen v0.0.0-20240108055932-686b39d75090
+	github.com/humanitec/humanitec-go-autogen v0.0.0-20240125162713-ab58fb4e601e
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/humanitec/humanitec-go-autogen v0.0.0-20240108055932-686b39d75090 h1:2/rQ2TfT/w2NTJCMiwaWupNPiP8g9TbXZktEmTYckj4=
 github.com/humanitec/humanitec-go-autogen v0.0.0-20240108055932-686b39d75090/go.mod h1:pIhrOozOV1z0sQewcCfEdsQjoaCBi7K6TixbKzE2TPI=
+github.com/humanitec/humanitec-go-autogen v0.0.0-20240125162713-ab58fb4e601e h1:tBHMUWLtZOTx049PI6DpRJscwKdVw5dPKNkqBMxFulg=
+github.com/humanitec/humanitec-go-autogen v0.0.0-20240125162713-ab58fb4e601e/go.mod h1:pIhrOozOV1z0sQewcCfEdsQjoaCBi7K6TixbKzE2TPI=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=

--- a/internal/provider/humanitec_client_test.go
+++ b/internal/provider/humanitec_client_test.go
@@ -58,7 +58,7 @@ func TestNewHumanitecClientWrite(t *testing.T) {
 	assert.NoError(err)
 
 	name := "changed"
-	_, err = humSvc.PatchCurrentUser(ctx, client.PatchCurrentUserJSONRequestBody{
+	_, err = humSvc.UpdateCurrentUserWithResponse(ctx, client.UpdateCurrentUserJSONRequestBody{
 		Name: &name,
 	})
 	assert.NoError(err)

--- a/internal/provider/humanitec_data.go
+++ b/internal/provider/humanitec_data.go
@@ -31,7 +31,7 @@ func (h *HumanitecData) fetchResourceDrivers(ctx context.Context) (map[string]*c
 		return h.driversByType, diags
 	}
 
-	httpResp, err := h.Client.GetOrgsOrgIdResourcesDriversWithResponse(ctx, h.OrgID)
+	httpResp, err := h.Client.ListResourceDriversWithResponse(ctx, h.OrgID)
 	if err != nil {
 		diags.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to get resource drivers, got error: %s", err))
 		return nil, diags
@@ -68,7 +68,7 @@ func (h *HumanitecData) fetchResourceTypes(ctx context.Context) (map[string]*cli
 		return h.typesByType, diags
 	}
 
-	httpResp, err := h.Client.GetOrgsOrgIdResourcesTypesWithResponse(ctx, h.OrgID)
+	httpResp, err := h.Client.ListResourceTypesWithResponse(ctx, h.OrgID)
 	if err != nil {
 		diags.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to get resource types, got error: %s", err))
 		return nil, diags

--- a/internal/provider/resource_account_resource.go
+++ b/internal/provider/resource_account_resource.go
@@ -132,11 +132,11 @@ func (r *ResourceAccountResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	httpResp, err := r.client.PostOrgsOrgIdResourcesAccountsWithResponse(ctx, r.orgId, client.PostOrgsOrgIdResourcesAccountsJSONRequestBody{
-		Id:          &id,
-		Name:        &name,
-		Type:        &accountType,
-		Credentials: &credentials,
+	httpResp, err := r.client.CreateResourceAccountWithResponse(ctx, r.orgId, client.CreateResourceAccountRequestRequest{
+		Id:          id,
+		Name:        name,
+		Type:        accountType,
+		Credentials: credentials,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to create resource account, got error: %s", err))
@@ -164,7 +164,7 @@ func (r *ResourceAccountResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	httpResp, err := r.client.GetOrgsOrgIdResourcesAccountsAccIdWithResponse(ctx, r.orgId, data.ID.ValueString())
+	httpResp, err := r.client.GetResourceAccountWithResponse(ctx, r.orgId, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read resource account, got error: %s", err))
 		return
@@ -200,7 +200,7 @@ func (r *ResourceAccountResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	httpResp, err := r.client.PatchOrgsOrgIdResourcesAccountsAccIdWithResponse(ctx, r.orgId, data.ID.ValueString(), client.PatchOrgsOrgIdResourcesAccountsAccIdJSONRequestBody{
+	httpResp, err := r.client.PatchResourceAccountWithResponse(ctx, r.orgId, data.ID.ValueString(), client.PatchResourceAccountJSONRequestBody{
 		Name:        &name,
 		Credentials: &credentials,
 	})
@@ -237,7 +237,7 @@ func (r *ResourceAccountResource) Delete(ctx context.Context, req resource.Delet
 	}
 
 	err := retry.RetryContext(ctx, deleteTimeout, func() *retry.RetryError {
-		httpResp, err := r.client.DeleteOrgsOrgIdResourcesAccountsAccIdWithResponse(ctx, r.orgId, data.ID.ValueString())
+		httpResp, err := r.client.DeleteResourceAccountWithResponse(ctx, r.orgId, data.ID.ValueString())
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -154,7 +154,7 @@ func (r *ResourceApplication) Create(ctx context.Context, req resource.CreateReq
 		}
 	}
 
-	httpResp, err := r.client.PostOrgsOrgIdAppsWithResponse(ctx, r.orgId, client.PostOrgsOrgIdAppsJSONRequestBody{
+	httpResp, err := r.client.CreateApplicationWithResponse(ctx, r.orgId, client.CreateApplicationJSONRequestBody{
 		Id:   id,
 		Name: name,
 		Env:  env,
@@ -191,12 +191,12 @@ func (r *ResourceApplication) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	var httpResp *client.GetOrgsOrgIdAppsAppIdResponse
+	var httpResp *client.GetApplicationResponse
 
 	err := retry.RetryContext(ctx, readTimeout, func() *retry.RetryError {
 		var err error
 
-		httpResp, err = r.client.GetOrgsOrgIdAppsAppIdWithResponse(ctx, r.orgId, data.ID.ValueString())
+		httpResp, err = r.client.GetApplicationWithResponse(ctx, r.orgId, data.ID.ValueString())
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}
@@ -250,7 +250,7 @@ func (r *ResourceApplication) Delete(ctx context.Context, req resource.DeleteReq
 	// Remove the app
 	appID := data.ID.ValueString()
 	err := retry.RetryContext(ctx, deleteTimeout, func() *retry.RetryError {
-		httpResp, err := r.client.DeleteOrgsOrgIdAppsAppIdWithResponse(ctx, r.orgId, appID)
+		httpResp, err := r.client.DeleteApplicationWithResponse(ctx, r.orgId, appID)
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -67,7 +67,7 @@ func TestAccResourceApplicationDeletedOutManually(t *testing.T) {
 					resource.TestCheckResourceAttr("humanitec_application.app_test", "name", "test-app-1"),
 					func(_ *terraform.State) error {
 						// Manually delete the application via the API
-						resp, err := client.DeleteOrgsOrgIdAppsAppIdWithResponse(ctx, orgID, id)
+						resp, err := client.DeleteApplicationWithResponse(ctx, orgID, id)
 						if err != nil {
 							return err
 						}

--- a/internal/provider/resource_application_user.go
+++ b/internal/provider/resource_application_user.go
@@ -143,10 +143,10 @@ func (r *ResourceApplicationUser) Create(ctx context.Context, req resource.Creat
 	appID := data.AppID.ValueString()
 	role := data.Role.ValueString()
 
-	var httpResp *client.PostOrgsOrgIdAppsAppIdUsersResponse
+	var httpResp *client.CreateUserRoleInAppResponse
 	err := retry.RetryContext(ctx, createTimeout, func() *retry.RetryError {
 		var err error
-		httpResp, err = r.client.PostOrgsOrgIdAppsAppIdUsersWithResponse(ctx, r.orgId, appID, client.PostOrgsOrgIdAppsAppIdUsersJSONRequestBody{
+		httpResp, err = r.client.CreateUserRoleInAppWithResponse(ctx, r.orgId, appID, client.CreateUserRoleInAppJSONRequestBody{
 			Id:   &userID,
 			Role: &role,
 		})
@@ -186,10 +186,10 @@ func (r *ResourceApplicationUser) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	var httpResp *client.GetOrgsOrgIdAppsAppIdUsersUserIdResponse
+	var httpResp *client.GetUserRoleInAppResponse
 	err := retry.RetryContext(ctx, defaultApplicationUserReadTimeout, func() *retry.RetryError {
 		var err error
-		httpResp, err = r.client.GetOrgsOrgIdAppsAppIdUsersUserIdWithResponse(ctx, r.orgId, data.AppID.ValueString(), data.UserID.ValueString())
+		httpResp, err = r.client.GetUserRoleInAppWithResponse(ctx, r.orgId, data.AppID.ValueString(), data.UserID.ValueString())
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}
@@ -235,7 +235,7 @@ func (r *ResourceApplicationUser) Update(ctx context.Context, req resource.Updat
 	appID := data.AppID.ValueString()
 	role := data.Role.ValueString()
 
-	httpResp, err := r.client.PatchOrgsOrgIdAppsAppIdUsersUserIdWithResponse(ctx, r.orgId, appID, userID, client.PatchOrgsOrgIdAppsAppIdUsersUserIdJSONRequestBody{
+	httpResp, err := r.client.UpdateUserRoleInAppWithResponse(ctx, r.orgId, appID, userID, client.UpdateUserRoleInAppJSONRequestBody{
 		Role: &role,
 	})
 	if err != nil {
@@ -268,7 +268,7 @@ func (r *ResourceApplicationUser) Delete(ctx context.Context, req resource.Delet
 	userID := data.UserID.ValueString()
 	applicationID := data.AppID.ValueString()
 
-	httpResp, err := r.client.DeleteOrgsOrgIdAppsAppIdUsersUserIdWithResponse(ctx, r.orgId, applicationID, userID)
+	httpResp, err := r.client.DeleteUserRoleInAppWithResponse(ctx, r.orgId, applicationID, userID)
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to delete resource application user, got error: %s", err))
 		return

--- a/internal/provider/resource_definition_criteria_resource.go
+++ b/internal/provider/resource_definition_criteria_resource.go
@@ -167,7 +167,7 @@ func (r *ResourceDefinitionCriteriaResource) Create(ctx context.Context, req res
 		return
 	}
 
-	httpResp, err := r.client().PostOrgsOrgIdResourcesDefsDefIdCriteriaWithResponse(ctx, r.orgId(), data.ResourceDefinitionID.ValueString(), client.PostOrgsOrgIdResourcesDefsDefIdCriteriaJSONRequestBody{
+	httpResp, err := r.client().CreateResourceDefinitionCriteriaWithResponse(ctx, r.orgId(), data.ResourceDefinitionID.ValueString(), client.CreateResourceDefinitionCriteriaJSONRequestBody{
 		AppId:   data.AppID.ValueStringPointer(),
 		EnvId:   data.EnvID.ValueStringPointer(),
 		EnvType: data.EnvType.ValueStringPointer(),
@@ -204,7 +204,7 @@ func (r *ResourceDefinitionCriteriaResource) Read(ctx context.Context, req resou
 		return
 	}
 
-	httpResp, err := r.client().GetOrgsOrgIdResourcesDefsDefIdWithResponse(ctx, r.orgId(), data.ResourceDefinitionID.ValueString())
+	httpResp, err := r.client().GetResourceDefinitionWithResponse(ctx, r.orgId(), data.ResourceDefinitionID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read resource definition, got error: %s", err))
 		return
@@ -299,7 +299,7 @@ func (r *ResourceDefinitionCriteriaResource) Delete(ctx context.Context, req res
 	force := data.ForceDelete.ValueBool()
 
 	err := retry.RetryContext(ctx, deleteTimeout, func() *retry.RetryError {
-		httpResp, err := r.client().DeleteOrgsOrgIdResourcesDefsDefIdCriteriaCriteriaIdWithResponse(ctx, r.orgId(), data.ResourceDefinitionID.ValueString(), data.ID.ValueString(), &client.DeleteOrgsOrgIdResourcesDefsDefIdCriteriaCriteriaIdParams{
+		httpResp, err := r.client().DeleteResourceDefinitionCriteriaWithResponse(ctx, r.orgId(), data.ResourceDefinitionID.ValueString(), data.ID.ValueString(), &client.DeleteResourceDefinitionCriteriaParams{
 			Force: &force,
 		})
 		if err != nil {

--- a/internal/provider/resource_environment_type.go
+++ b/internal/provider/resource_environment_type.go
@@ -100,7 +100,7 @@ func (r *ResourceEnvironmentType) Create(ctx context.Context, req resource.Creat
 
 	id := data.ID.ValueString()
 
-	httpResp, err := r.client.PostOrgsOrgIdEnvTypesWithResponse(ctx, r.orgId, client.PostOrgsOrgIdEnvTypesJSONRequestBody{
+	httpResp, err := r.client.CreateEnvironmentTypeWithResponse(ctx, r.orgId, client.CreateEnvironmentTypeJSONRequestBody{
 		Id:          id,
 		Description: data.Description.ValueStringPointer(),
 	})
@@ -130,7 +130,7 @@ func (r *ResourceEnvironmentType) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	httpResp, err := r.client.GetOrgsOrgIdEnvTypesEnvTypeIdWithResponse(ctx, r.orgId, data.ID.ValueString())
+	httpResp, err := r.client.GetEnvironmentTypeWithResponse(ctx, r.orgId, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read environment type, got error: %s", err))
 		return
@@ -160,7 +160,7 @@ func (r *ResourceEnvironmentType) Delete(ctx context.Context, req resource.Delet
 		return
 	}
 
-	httpResp, err := r.client.DeleteOrgsOrgIdEnvTypesEnvTypeIdWithResponse(ctx, r.orgId, data.ID.ValueString())
+	httpResp, err := r.client.DeleteEnvironmentTypeWithResponse(ctx, r.orgId, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to delete environment type, got error: %s", err))
 		return

--- a/internal/provider/resource_environment_type_user.go
+++ b/internal/provider/resource_environment_type_user.go
@@ -143,10 +143,10 @@ func (r *ResourceEnvironmentTypeUser) Create(ctx context.Context, req resource.C
 	envTypeID := data.EnvTypeID.ValueString()
 	role := data.Role.ValueString()
 
-	var httpResp *client.PostOrgsOrgIdEnvTypesEnvTypeUsersResponse
+	var httpResp *client.CreateUserRoleInEnvTypeResponse
 	err := retry.RetryContext(ctx, createTimeout, func() *retry.RetryError {
 		var err error
-		httpResp, err = r.client.PostOrgsOrgIdEnvTypesEnvTypeUsersWithResponse(ctx, r.orgId, envTypeID, client.PostOrgsOrgIdEnvTypesEnvTypeUsersJSONRequestBody{
+		httpResp, err = r.client.CreateUserRoleInEnvTypeWithResponse(ctx, r.orgId, envTypeID, client.CreateUserRoleInEnvTypeJSONRequestBody{
 			Id:   &userID,
 			Role: &role,
 		})
@@ -186,10 +186,10 @@ func (r *ResourceEnvironmentTypeUser) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	var httpResp *client.GetOrgsOrgIdEnvTypesEnvTypeUsersUserIdResponse
+	var httpResp *client.GetUserRoleInEnvTypeResponse
 	err := retry.RetryContext(ctx, defaultEnvironmentTypeUserReadTimeout, func() *retry.RetryError {
 		var err error
-		httpResp, err = r.client.GetOrgsOrgIdEnvTypesEnvTypeUsersUserIdWithResponse(ctx, r.orgId, data.EnvTypeID.ValueString(), data.UserID.ValueString())
+		httpResp, err = r.client.GetUserRoleInEnvTypeWithResponse(ctx, r.orgId, data.EnvTypeID.ValueString(), data.UserID.ValueString())
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}
@@ -235,7 +235,7 @@ func (r *ResourceEnvironmentTypeUser) Update(ctx context.Context, req resource.U
 	envTypeID := data.EnvTypeID.ValueString()
 	role := data.Role.ValueString()
 
-	httpResp, err := r.client.PatchOrgsOrgIdEnvTypesEnvTypeUsersUserIdWithResponse(ctx, r.orgId, envTypeID, userID, client.PatchOrgsOrgIdAppsAppIdUsersUserIdJSONRequestBody{
+	httpResp, err := r.client.UpdateUserRoleInEnvTypeWithResponse(ctx, r.orgId, envTypeID, userID, client.UpdateUserRoleInEnvTypeJSONRequestBody{
 		Role: &role,
 	})
 	if err != nil {
@@ -268,7 +268,7 @@ func (r *ResourceEnvironmentTypeUser) Delete(ctx context.Context, req resource.D
 	userID := data.UserID.ValueString()
 	applicationID := data.EnvTypeID.ValueString()
 
-	httpResp, err := r.client.DeleteOrgsOrgIdEnvTypesEnvTypeUsersUserIdWithResponse(ctx, r.orgId, applicationID, userID)
+	httpResp, err := r.client.DeleteUserRoleInEnvTypeWithResponse(ctx, r.orgId, applicationID, userID)
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to delete resource environment type user, got error: %s", err))
 		return

--- a/internal/provider/resource_resource_driver.go
+++ b/internal/provider/resource_resource_driver.go
@@ -150,7 +150,7 @@ func (r *ResourceResourceDriver) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	id := data.ID.ValueStringPointer()
+	id := data.ID.ValueString()
 
 	var inputsSchema map[string]interface{}
 	if err := json.Unmarshal([]byte(data.InputsSchema.ValueString()), &inputsSchema); err != nil {
@@ -172,7 +172,7 @@ func (r *ResourceResourceDriver) Create(ctx context.Context, req resource.Create
 		accountTypes = append(accountTypes, v.ValueString())
 	}
 
-	httpResp, err := r.client.PostOrgsOrgIdResourcesDriversWithResponse(ctx, r.orgId, client.CreateDriverRequestRequest{
+	httpResp, err := r.client.CreateResourceDriverWithResponse(ctx, r.orgId, client.CreateDriverRequestRequest{
 		Id:           id,
 		AccountTypes: accountTypes,
 		InputsSchema: inputsSchema,
@@ -206,7 +206,7 @@ func (r *ResourceResourceDriver) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	httpResp, err := r.client.GetOrgsOrgIdResourcesDriversDriverIdWithResponse(ctx, r.orgId, data.ID.ValueString())
+	httpResp, err := r.client.GetResourceDriverWithResponse(ctx, r.orgId, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read resource driver, got error: %s", err))
 		return
@@ -253,7 +253,7 @@ func (r *ResourceResourceDriver) Update(ctx context.Context, req resource.Update
 		}
 	}
 
-	httpResp, err := r.client.PutOrgsOrgIdResourcesDriversDriverIdWithResponse(ctx, r.orgId, id, client.UpdateDriverRequestRequest{
+	httpResp, err := r.client.UpdateResourceDriverWithResponse(ctx, r.orgId, id, client.UpdateDriverRequestRequest{
 		AccountTypes: accountTypes,
 		InputsSchema: inputsSchema,
 		Target:       data.Target.ValueString(),
@@ -285,7 +285,7 @@ func (r *ResourceResourceDriver) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	httpResp, err := r.client.DeleteOrgsOrgIdResourcesDriversDriverIdWithResponse(ctx, r.orgId, data.ID.ValueString())
+	httpResp, err := r.client.DeleteResourceDriverWithResponse(ctx, r.orgId, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to delete resource driver, got error: %s", err))
 		return


### PR DESCRIPTION
I needed an updated client in the terraform provider so that I can use a new API behavior. However this brings in the client with new operation ids for resources, apps, and envs! So I must first upgrade this repo over to the new names and keep the changes isolated.



