### PR TITLE
fix(environment): don't set from_deploy_id

### DIFF
--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -288,12 +288,6 @@ func (r *ResourceEnvironment) ImportState(ctx context.Context, req resource.Impo
 }
 
 func parseEnvironmentResponse(appID string, res *client.EnvironmentResponse, data *EnvironmentModel) {
-	var fromDeployId *string
-	if res.FromDeploy != nil {
-		fromDeployId = &res.FromDeploy.Id
-	}
-
-	data.FromDeployID = types.StringPointerValue(fromDeployId)
 	data.AppID = types.StringValue(appID)
 	data.ID = types.StringValue(res.Id)
 	data.Name = types.StringValue(res.Name)


### PR DESCRIPTION
When a new set is deploy, the value of this field changes and TF constantly demands the environment to be recreated.

```
# humanitec_environment.platform_staging must be replaced
-/+ resource "humanitec_environment" "platform_staging" {
      ~ from_deploy_id = "17d496de579fb118" -> "17d4933cec88acc7" # forces replacement
        id             = "staging"
        name           = "Staging"
        # (2 unchanged attributes hidden)
    }
```