### PR TITLE
fix: mark resource definition driver type as updatable

### DIFF
--- a/internal/provider/resource_definition_resource.go
+++ b/internal/provider/resource_definition_resource.go
@@ -113,9 +113,6 @@ func (r *ResourceDefinitionResource) Schema(ctx context.Context, req resource.Sc
 			"driver_type": schema.StringAttribute{
 				MarkdownDescription: "The driver to be used to create the resource.",
 				Required:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"driver_account": schema.StringAttribute{
 				MarkdownDescription: "Security account required by the driver.",


### PR DESCRIPTION
Removing the modifier was missed in https://github.com/humanitec/terraform-provider-humanitec/pull/92