### PR TITLE
fix: replace secret store on id change

### DIFF
--- a/internal/provider/resource_secret_store.go
+++ b/internal/provider/resource_secret_store.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/humanitec/humanitec-go-autogen"
 	"github.com/humanitec/humanitec-go-autogen/client"
@@ -92,6 +94,9 @@ func (*SecretStore) Schema(ctx context.Context, req resource.SchemaRequest, resp
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the Secret Store.",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"primary": schema.BoolAttribute{
 				MarkdownDescription: "Whether the Secret Store is the Primary one for the organization.",

--- a/internal/provider/resource_secret_store_test.go
+++ b/internal/provider/resource_secret_store_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestAccResourceSecretStore_AzureKV(t *testing.T) {
 	id := fmt.Sprintf("azurekv-test-%d", time.Now().UnixNano())
+	newId := fmt.Sprintf("azurekv-test-new-%d", time.Now().UnixNano())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -44,6 +45,17 @@ func TestAccResourceSecretStore_AzureKV(t *testing.T) {
 			{
 				Config: testAccSecretStoreAzureKV(id, "tenant-id", "azurekv-url-changed", "client-id-changed", "client-secret"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("humanitec_secretstore.secret_store_azurekv_test", "primary", "false"),
+					resource.TestCheckResourceAttr("humanitec_secretstore.secret_store_azurekv_test", "azurekv.tenant_id", "tenant-id"),
+					resource.TestCheckResourceAttr("humanitec_secretstore.secret_store_azurekv_test", "azurekv.url", "azurekv-url-changed"),
+					resource.TestCheckResourceAttr("humanitec_secretstore.secret_store_azurekv_test", "azurekv.auth.client_id", "client-id-changed"),
+				),
+			},
+			// Replace and Read testing
+			{
+				Config: testAccSecretStoreAzureKV(newId, "tenant-id", "azurekv-url-changed", "client-id-changed", "client-secret"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("humanitec_secretstore.secret_store_azurekv_test", "id", newId),
 					resource.TestCheckResourceAttr("humanitec_secretstore.secret_store_azurekv_test", "primary", "false"),
 					resource.TestCheckResourceAttr("humanitec_secretstore.secret_store_azurekv_test", "azurekv.tenant_id", "tenant-id"),
 					resource.TestCheckResourceAttr("humanitec_secretstore.secret_store_azurekv_test", "azurekv.url", "azurekv-url-changed"),


### PR DESCRIPTION
This PR resolves an issue preventing updates to the id of the secret store. Previously, providers attempted to modify the id field directly, which the API does not permit. The new behavior replaces the entire resource instead.

Example output:
```
$terraform apply
humanitec_secretstore.ss: Refreshing state... [id=saml-test-ss-1]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # humanitec_secretstore.ss must be replaced
-/+ resource "humanitec_secretstore" "ss" {
      ~ id      = "saml-test-ss-1" -> "saml-test-ss-2" # forces replacement
        # (2 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

humanitec_secretstore.ss: Destroying... [id=saml-test-ss-1]
humanitec_secretstore.ss: Destruction complete after 0s
humanitec_secretstore.ss: Creating...
humanitec_secretstore.ss: Creation complete after 0s [id=saml-test-ss-2]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```