### PR TITLE
feat: remove init env from application resource

### DIFF
--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -4,11 +4,20 @@ page_title: "humanitec_application Resource - terraform-provider-humanitec"
 subcategory: ""
 description: |-
   An Application is a collection of Workloads that work together. When deployed, all Workloads in an Application are deployed to the same namespace.
+  
+  NOTE:  Version 1.7.0 removed the option to create an initial environment via the application resource. Environment creation is now fully separate and must be triggered using the humanitec_environment https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/environment resource.
+  To replicate the previous application resource behavior, use the example below.
 ---
 
 # humanitec_application (Resource)
 
 An Application is a collection of Workloads that work together. When deployed, all Workloads in an Application are deployed to the same namespace.
+
+---
+**_NOTE:_**  Version 1.7.0 removed the option to create an initial environment via the application resource. Environment creation is now fully separate and must be triggered using the [humanitec_environment](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/environment) resource.
+To replicate the previous application resource behavior, use the example below.
+
+---
 
 ## Example Usage
 
@@ -18,15 +27,11 @@ resource "humanitec_application" "example" {
   name = "An example app"
 }
 
-resource "humanitec_application" "example" {
-  id   = "example"
-  name = "An example app with default development environment overriden"
-
-  env = {
-    id   = "dev"
-    name = "Dev"
-    type = "development"
-  }
+resource "humanitec_environment" "example" {
+  app_id = humanitec_application.example.id
+  id     = "development"
+  name   = "Development"
+  type   = "development"
 }
 ```
 
@@ -40,18 +45,7 @@ resource "humanitec_application" "example" {
 
 ### Optional
 
-- `env` (Attributes) Initial environment to create. Will be `development` by default. **Warning**: Change `env` value after creation will force destroy this resource and his dependencies (include environments, values, webhook, workloads, etc.). (see [below for nested schema](#nestedatt--env))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
-
-<a id="nestedatt--env"></a>
-### Nested Schema for `env`
-
-Required:
-
-- `id` (String) The ID the Environment is referenced as.
-- `name` (String) The Human-friendly name for the Environment.
-- `type` (String) The Environment Type. This is used for organizing and managing Environments.
-
 
 <a id="nestedatt--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/examples/resources/humanitec_application/resource.tf
+++ b/examples/resources/humanitec_application/resource.tf
@@ -3,13 +3,9 @@ resource "humanitec_application" "example" {
   name = "An example app"
 }
 
-resource "humanitec_application" "example" {
-  id   = "example"
-  name = "An example app with default development environment overriden"
-
-  env = {
-    id   = "dev"
-    name = "Dev"
-    type = "development"
-  }
+resource "humanitec_environment" "example" {
+  app_id = humanitec_application.example.id
+  id     = "development"
+  name   = "Development"
+  type   = "development"
 }

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,9 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
-	github.com/humanitec/humanitec-go-autogen v0.0.0-20240620130303-6979d29fd1fa
+	github.com/humanitec/humanitec-go-autogen v0.0.0-20250205144346-704632a4c27d
 	github.com/justinrixx/retryhttp v1.0.1
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbg
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/humanitec/humanitec-go-autogen v0.0.0-20240620130303-6979d29fd1fa h1:afMWF/XDAPgxlfRW6J89UTyptJb/SG7tFiAQzB5ToCY=
-github.com/humanitec/humanitec-go-autogen v0.0.0-20240620130303-6979d29fd1fa/go.mod h1:WqItJ/MhAHcjP7LIhIt2/NrgXeXRbLuxvXlin7qY0j4=
+github.com/humanitec/humanitec-go-autogen v0.0.0-20250205144346-704632a4c27d h1:hOYyO/mCLyM/1ASlNaNxi9YDTqzsOnjfbWvZMF+iin0=
+github.com/humanitec/humanitec-go-autogen v0.0.0-20250205144346-704632a4c27d/go.mod h1:3npLY/X5ijQIV40CwX9ag9VuzRPgg9+x4DFHgrBbfvg=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
@@ -203,8 +203,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/resource_account_resource.go
+++ b/internal/provider/resource_account_resource.go
@@ -132,7 +132,7 @@ func (r *ResourceAccountResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	httpResp, err := r.client.CreateResourceAccountWithResponse(ctx, r.orgId, client.CreateResourceAccountRequestRequest{
+	httpResp, err := r.client.CreateResourceAccountWithResponse(ctx, r.orgId, &client.CreateResourceAccountParams{}, client.CreateResourceAccountRequestRequest{
 		Id:          id,
 		Name:        name,
 		Type:        accountType,
@@ -206,7 +206,7 @@ func (r *ResourceAccountResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	httpResp, err := r.client.PatchResourceAccountWithResponse(ctx, r.orgId, data.ID.ValueString(), client.PatchResourceAccountJSONRequestBody{
+	httpResp, err := r.client.PatchResourceAccountWithResponse(ctx, r.orgId, data.ID.ValueString(), &client.PatchResourceAccountParams{}, client.PatchResourceAccountJSONRequestBody{
 		Name:        &name,
 		Credentials: &credentials,
 	})

--- a/internal/provider/resource_rule_test.go
+++ b/internal/provider/resource_rule_test.go
@@ -147,12 +147,13 @@ func testAccResourceRule(appID, artefact string) string {
 	resource "humanitec_application" "rule_test" {
 		id = "%s"
 		name = "rule-test"
-
-		env = {
-			id   = "dev"
-			name = "dev"
-			type = "development"
-		}
+	}
+	
+	resource "humanitec_environment" "dev" {
+		app_id = humanitec_application.rule_test.id
+		id = "dev"
+		name = "dev"
+		type = "development"
 	}
 
 	resource "humanitec_rule" "rule1" {
@@ -171,12 +172,13 @@ func testAccResourceRule_Full(appID, artefact string) string {
 	resource "humanitec_application" "rule_test" {
 		id = "%s"
 		name = "rule-test"
+	}
 
-		env = {
-			id   = "dev"
-			name = "dev"
-			type = "development"
-		}
+	resource "humanitec_environment" "dev" {
+		app_id = humanitec_application.rule_test.id
+		id = "dev"
+		name = "dev"
+		type = "development"
 	}
 
 	resource "humanitec_rule" "rule1" {

--- a/internal/provider/resource_value_test.go
+++ b/internal/provider/resource_value_test.go
@@ -304,12 +304,13 @@ func testAccResourceVALUETestAccResourceValueWithEnv(appID, envID, key, descript
 resource "humanitec_application" "val_test" {
 	id   = "%s"
 	name = "val-test"
+}
 
-	env = {
-		id   = "%s"
-		name = "dev"
-		type = "development"
-	}
+resource "humanitec_environment" "dev" {
+	app_id = humanitec_application.val_test.id
+	id = "%s"
+	name = "dev"
+	type = "development"
 }
 
 resource "humanitec_value" "app_val1" {


### PR DESCRIPTION
This PR introduces a breaking change in the application resource by removing initial environment creation. Since this feature was originally added due to a Humanitec limitation, there is no reason to continue supporting it.

From now on, applications will be created without any environments by default. Environments can be created separately via Terraform using the humanitec_environment resource. This change improves the integrity and flexibility of the Humanitec Terraform Provider.

Old TF code example:
```hcl
resource "humanitec_application" "example" {
  id   = "example"
  name = "An example app"

  env = {
    id   = "development"
    name = "An example environment"
    type = "development"
  }
}
```

New TF code example:
```hcl
resource "humanitec_application" "example" {
  id   = "example"
  name = "An example app"
}

resource "humanitec_environment" "example" {
  app_id = humanitec_application.example.id
  id     = "development"
  name   = "An example environment"
  type   = "development"
}
```