### PR TITLE
fix: mismatch app value when env value is missing on read

### DIFF
--- a/internal/provider/resource_value.go
+++ b/internal/provider/resource_value.go
@@ -339,7 +339,7 @@ func (r *ResourceValue) Read(ctx context.Context, req resource.ReadRequest, resp
 	// TODO Ideally the API should allow to fetch a value by KEY
 	key := data.Key.ValueString()
 	value, found := findInSlicePtr(res, func(a client.ValueResponse) bool {
-		return a.Key == key
+		return a.Key == key && (data.EnvID.IsNull() || a.Source == client.Env)
 	})
 
 	if !found {

--- a/internal/provider/resource_value_test.go
+++ b/internal/provider/resource_value_test.go
@@ -331,6 +331,15 @@ func TestAccResourceValueWithEnvEnvDeletedOutManually(t *testing.T) {
 				),
 				ExpectNonEmptyPlan: true,
 			},
+			// Reapply after manually deleted testing
+			{
+				Config: testAccResourceVALUETestAccResourceValueWithEnv(appID, envID, key, "Example value"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("humanitec_value.app_val1", "key", key),
+					resource.TestCheckResourceAttr("humanitec_value.app_env_val1", "key", key),
+					resource.TestCheckResourceAttr("humanitec_value.app_env_val1", "description", "Example value"),
+				),
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})


### PR DESCRIPTION
This PR adds additional filters to the values list to exclude all app values when reading environment variables. This ensures that if an environment variable is manually deleted, the app value will not be mismatched, and the state of that environment variable will be removed accordingly