### PR TITLE
feat(application): allow updating name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
-	github.com/humanitec/humanitec-go-autogen v0.0.0-20250205144346-704632a4c27d
+	github.com/humanitec/humanitec-go-autogen v0.0.0-20250407150854-07692805fb34
 	github.com/justinrixx/retryhttp v1.0.1
 	github.com/stretchr/testify v1.10.0
 	sigs.k8s.io/yaml v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbg
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/humanitec/humanitec-go-autogen v0.0.0-20250205144346-704632a4c27d h1:hOYyO/mCLyM/1ASlNaNxi9YDTqzsOnjfbWvZMF+iin0=
-github.com/humanitec/humanitec-go-autogen v0.0.0-20250205144346-704632a4c27d/go.mod h1:3npLY/X5ijQIV40CwX9ag9VuzRPgg9+x4DFHgrBbfvg=
+github.com/humanitec/humanitec-go-autogen v0.0.0-20250407150854-07692805fb34 h1:ezD2UXnECAfuD+eqNft3dbMKv3AfGzEzSGoC5+m1pPY=
+github.com/humanitec/humanitec-go-autogen v0.0.0-20250407150854-07692805fb34/go.mod h1:3npLY/X5ijQIV40CwX9ag9VuzRPgg9+x4DFHgrBbfvg=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -113,7 +113,7 @@ func (p *HumanitecProvider) Configure(ctx context.Context, req provider.Configur
 		resp.Diagnostics.AddWarning(
 			"Environment variable HUMANITEC_HOST has been deprecated",
 			"Environment variable HUMANITEC_HOST has been deprecated "+
-				"please use HUMANITEC_API_PREFIX instead to set your api prefix to the terraform driver.")
+				"please use HUMANITEC_API_PREFIX instead to set your api prefix to the terraform provider.")
 	}
 
 	if os.Getenv("HUMANITEC_API_PREFIX") != "" {
@@ -140,7 +140,7 @@ func (p *HumanitecProvider) Configure(ctx context.Context, req provider.Configur
 		resp.Diagnostics.AddWarning(
 			"Attribute host has been deprecated",
 			"Attribute hostT has been deprecated "+
-				"please use api_prefix instead to set your api prefix to the terraform driver.")
+				"please use api_prefix instead to set your api prefix to the terraform provider.")
 	}
 	if !data.APIPrefix.IsNull() {
 		apiPrefix = data.APIPrefix.ValueString()

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAccResourceApplication(t *testing.T) {
+func TestAccResourceApplicationWithUpdate(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 	id := fmt.Sprintf("test-%d", time.Now().UnixNano())
@@ -28,6 +28,9 @@ func TestAccResourceApplication(t *testing.T) {
 	var client *humanitec.Client
 	var err error
 
+	name := "Test TF App Name"
+	updatedName := "Updated Test TF App Name"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -39,10 +42,18 @@ func TestAccResourceApplication(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccResourceApplication(id, "test-app-1"),
+				Config: testAccResourceApplication(id, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("humanitec_application.app_test", "id", id),
-					resource.TestCheckResourceAttr("humanitec_application.app_test", "name", "test-app-1"),
+					resource.TestCheckResourceAttr("humanitec_application.app_test", "name", name),
+					testCheckNoEnvironmentsAreCreated(ctx, &client, orgID, id),
+				),
+			},
+			{
+				Config: testAccResourceApplication(id, updatedName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("humanitec_application.app_test", "id", id),
+					resource.TestCheckResourceAttr("humanitec_application.app_test", "name", updatedName),
 					testCheckNoEnvironmentsAreCreated(ctx, &client, orgID, id),
 				),
 			},

--- a/internal/provider/resource_application_user.go
+++ b/internal/provider/resource_application_user.go
@@ -134,8 +134,8 @@ func (r *ResourceApplicationUser) Create(ctx context.Context, req resource.Creat
 	err := retry.RetryContext(ctx, createTimeout, func() *retry.RetryError {
 		var err error
 		httpResp, err = r.client.CreateUserRoleInAppWithResponse(ctx, r.orgId, appID, client.CreateUserRoleInAppJSONRequestBody{
-			Id:   &userID,
-			Role: &role,
+			Id:   userID,
+			Role: role,
 		})
 		if err != nil {
 			return retry.NonRetryableError(err)
@@ -213,7 +213,7 @@ func (r *ResourceApplicationUser) Update(ctx context.Context, req resource.Updat
 	role := data.Role.ValueString()
 
 	httpResp, err := r.client.UpdateUserRoleInAppWithResponse(ctx, r.orgId, appID, userID, client.UpdateUserRoleInAppJSONRequestBody{
-		Role: &role,
+		Role: role,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to update resource application user, got error: %s", err))

--- a/internal/provider/resource_environment_type_user.go
+++ b/internal/provider/resource_environment_type_user.go
@@ -134,8 +134,8 @@ func (r *ResourceEnvironmentTypeUser) Create(ctx context.Context, req resource.C
 	err := retry.RetryContext(ctx, createTimeout, func() *retry.RetryError {
 		var err error
 		httpResp, err = r.client.CreateUserRoleInEnvTypeWithResponse(ctx, r.orgId, envTypeID, client.CreateUserRoleInEnvTypeJSONRequestBody{
-			Id:   &userID,
-			Role: &role,
+			Id:   userID,
+			Role: role,
 		})
 		if err != nil {
 			return retry.NonRetryableError(err)
@@ -211,7 +211,7 @@ func (r *ResourceEnvironmentTypeUser) Update(ctx context.Context, req resource.U
 	role := data.Role.ValueString()
 
 	httpResp, err := r.client.UpdateUserRoleInEnvTypeWithResponse(ctx, r.orgId, envTypeID, userID, client.UpdateUserRoleInEnvTypeJSONRequestBody{
-		Role: &role,
+		Role: role,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to update resource environment type user, got error: %s", err))

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -196,7 +196,7 @@ func (r *ResourceUser) Update(ctx context.Context, req resource.UpdateRequest, r
 	role := data.Role.ValueString()
 
 	httpResp, err := r.client.UpdateUserRoleInOrgWithResponse(ctx, r.orgId, id, client.RoleRequest{
-		Role: &role,
+		Role: role,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to update user, got error: %s", err))

--- a/internal/provider/users_data_source.go
+++ b/internal/provider/users_data_source.go
@@ -116,7 +116,7 @@ func (d *UsersDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	httpResp, err := d.client.ListUserRolesInOrgWithResponse(ctx, d.orgId)
+	httpResp, err := d.client.ListUserRolesInOrgWithResponse(ctx, d.orgId, &client.ListUserRolesInOrgParams{})
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to list users, got error: %s", err))
 		return


### PR DESCRIPTION
This leverages the [new API endpoint](https://api-docs.humanitec.com/#tag/Application/operation/patchApplication) to update the application name to allow updating an application name also via CLI.

Ticket: https://humanitec.atlassian.net/browse/WAL-10958.