### PR TITLE
Update `user_id` doc for `application_user` and `environment_type_user`: "user or group"

### DIFF
--- a/docs/resources/application_user.md
+++ b/docs/resources/application_user.md
@@ -26,7 +26,7 @@ resource "humanitec_application_user" "another_owner" {
 ### Required
 
 - `app_id` (String) The Application ID.
-- `role` (String) The role that this user holds. Could be `viewer`, `developer` or `owner`.
+- `role` (String) The role that this user or group holds. Could be `viewer`, `developer` or `owner`.
 - `user_id` (String) The user or group ID that holds the role
 
 ### Optional

--- a/docs/resources/application_user.md
+++ b/docs/resources/application_user.md
@@ -3,12 +3,12 @@
 page_title: "humanitec_application_user Resource - terraform-provider-humanitec"
 subcategory: ""
 description: |-
-  Resource Application User holds the mapping of role to user for an application.
+  Resource Application User holds the mapping of role to user or group for an application.
 ---
 
 # humanitec_application_user (Resource)
 
-Resource Application User holds the mapping of role to user for an application.
+Resource Application User holds the mapping of role to user or group for an application.
 
 ## Example Usage
 
@@ -27,7 +27,7 @@ resource "humanitec_application_user" "another_owner" {
 
 - `app_id` (String) The Application ID.
 - `role` (String) The role that this user holds. Could be `viewer`, `developer` or `owner`.
-- `user_id` (String) The user ID that hold the role
+- `user_id` (String) The user or group ID that hold the role
 
 ### Optional
 

--- a/docs/resources/application_user.md
+++ b/docs/resources/application_user.md
@@ -27,7 +27,7 @@ resource "humanitec_application_user" "another_owner" {
 
 - `app_id` (String) The Application ID.
 - `role` (String) The role that this user holds. Could be `viewer`, `developer` or `owner`.
-- `user_id` (String) The user or group ID that hold the role
+- `user_id` (String) The user or group ID that holds the role
 
 ### Optional
 

--- a/docs/resources/environment_type_user.md
+++ b/docs/resources/environment_type_user.md
@@ -3,12 +3,12 @@
 page_title: "humanitec_environment_type_user Resource - terraform-provider-humanitec"
 subcategory: ""
 description: |-
-  Resource Environment Type User holds the mapping of role to user for an environment type.
+  Resource Environment Type User holds the mapping of role to user or group for an environment type.
 ---
 
 # humanitec_environment_type_user (Resource)
 
-Resource Environment Type User holds the mapping of role to user for an environment type.
+Resource Environment Type User holds the mapping of role to user or group for an environment type.
 
 ## Example Usage
 
@@ -26,8 +26,8 @@ resource "humanitec_environment_type_user" "another_deployer" {
 ### Required
 
 - `env_type_id` (String) The Environment Type.
-- `role` (String) The role that this user holds. At this time, only `deployer` is supported.
-- `user_id` (String) The user ID that hold the role
+- `role` (String) The role that this user or group holds. At this time, only `deployer` is supported.
+- `user_id` (String) The user or group ID that holds the role
 
 ### Optional
 

--- a/internal/provider/resource_application_user.go
+++ b/internal/provider/resource_application_user.go
@@ -54,7 +54,7 @@ func (r *ResourceApplicationUser) Metadata(ctx context.Context, req resource.Met
 
 func (r *ResourceApplicationUser) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Resource Application User holds the mapping of role to user for an application.",
+		MarkdownDescription: "Resource Application User holds the mapping of role to user or group for an application.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -71,7 +71,7 @@ func (r *ResourceApplicationUser) Schema(ctx context.Context, req resource.Schem
 				},
 			},
 			"user_id": schema.StringAttribute{
-				MarkdownDescription: "The user ID that hold the role",
+				MarkdownDescription: "The user or group ID that holds the role",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/internal/provider/resource_application_user.go
+++ b/internal/provider/resource_application_user.go
@@ -78,7 +78,7 @@ func (r *ResourceApplicationUser) Schema(ctx context.Context, req resource.Schem
 				},
 			},
 			"role": schema.StringAttribute{
-				MarkdownDescription: "The role that this user holds. Could be `viewer`, `developer` or `owner`.",
+				MarkdownDescription: "The role that this user or group holds. Could be `viewer`, `developer` or `owner`.",
 				Required:            true,
 			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{

--- a/internal/provider/resource_environment_type_user.go
+++ b/internal/provider/resource_environment_type_user.go
@@ -54,7 +54,7 @@ func (r *ResourceEnvironmentTypeUser) Metadata(ctx context.Context, req resource
 
 func (r *ResourceEnvironmentTypeUser) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Resource Environment Type User holds the mapping of role to user for an environment type.",
+		MarkdownDescription: "Resource Environment Type User holds the mapping of role to user or group for an environment type.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -71,14 +71,14 @@ func (r *ResourceEnvironmentTypeUser) Schema(ctx context.Context, req resource.S
 				},
 			},
 			"user_id": schema.StringAttribute{
-				MarkdownDescription: "The user ID that hold the role",
+				MarkdownDescription: "The user or group ID that holds the role",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"role": schema.StringAttribute{
-				MarkdownDescription: "The role that this user holds. At this time, only `deployer` is supported.",
+				MarkdownDescription: "The role that this user or group holds. At this time, only `deployer` is supported.",
 				Required:            true,
 			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{


### PR DESCRIPTION
This is not creating the `resource_group` yet, but it's aligning doc about the `user_id` field in [`application_user`](https://registry.terraform.io/providers/humanitec/humanitec/latest/docs/resources/application_user) that could be a `user or group ID`, aligned with the associated API docs now: https://api-docs.humanitec.com/#tag/UserRole/operation/createUserRoleInApp.

https://developer.humanitec.com/platform-orchestrator/security/authentication/#groups