### PR TITLE
feat(def): allow set params into co-provisioned resources

### DIFF
--- a/docs/resources/resource_definition.md
+++ b/docs/resources/resource_definition.md
@@ -26,6 +26,24 @@ resource "humanitec_resource_definition" "s3" {
   }
 }
 
+resource "humanitec_resource_definition" "dns" {
+  id   = "dns-newapp"
+  name = "dns-newapp"
+  type = "dns"
+
+  driver_type = "humanitec/newapp-io-dns"
+
+  provision = {
+    "ingress" = {
+      is_dependent     = false
+      match_dependents = false
+      params = jsonencode({
+        "host" = "$${resources.dns.host}"
+      })
+    }
+  }
+}
+
 resource "humanitec_resource_definition" "postgres" {
   id          = "db-dev"
   name        = "db-dev"
@@ -144,6 +162,7 @@ Optional:
 
 - `is_dependent` (Boolean) If the co-provisioned resource is dependent on the current one.
 - `match_dependents` (Boolean) If the resources dependant on the main resource, are also dependant on the co-provisioned one.
+- `params` (String) Parameters to be passed to the co-provisioned resource. JSON encoded string.
 
 
 <a id="nestedatt--timeouts"></a>

--- a/examples/resources/humanitec_resource_definition/resource.tf
+++ b/examples/resources/humanitec_resource_definition/resource.tf
@@ -11,6 +11,24 @@ resource "humanitec_resource_definition" "s3" {
   }
 }
 
+resource "humanitec_resource_definition" "dns" {
+  id   = "dns-newapp"
+  name = "dns-newapp"
+  type = "dns"
+
+  driver_type = "humanitec/newapp-io-dns"
+
+  provision = {
+    "ingress" = {
+      is_dependent     = false
+      match_dependents = false
+      params = jsonencode({
+        "host" = "$${resources.dns.host}"
+      })
+    }
+  }
+}
+
 resource "humanitec_resource_definition" "postgres" {
   id          = "db-dev"
   name        = "db-dev"

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
-	github.com/humanitec/humanitec-go-autogen v0.0.0-20250505082423-b8612e8ee860
+	github.com/humanitec/humanitec-go-autogen v0.0.0-20250701114457-dd9b166c00c3
 	github.com/justinrixx/retryhttp v1.0.1
 	github.com/stretchr/testify v1.10.0
 	sigs.k8s.io/yaml v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbg
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/humanitec/humanitec-go-autogen v0.0.0-20250505082423-b8612e8ee860 h1:F+0Rkksl0B8RkLZ9U14HNtmmpwb7/os0ehoHYKpaxB0=
-github.com/humanitec/humanitec-go-autogen v0.0.0-20250505082423-b8612e8ee860/go.mod h1:3npLY/X5ijQIV40CwX9ag9VuzRPgg9+x4DFHgrBbfvg=
+github.com/humanitec/humanitec-go-autogen v0.0.0-20250701114457-dd9b166c00c3 h1:JqRmoXHptO5WAu38sh/yiV0cT8MNREQCoI/G+RO6S7E=
+github.com/humanitec/humanitec-go-autogen v0.0.0-20250701114457-dd9b166c00c3/go.mod h1:3npLY/X5ijQIV40CwX9ag9VuzRPgg9+x4DFHgrBbfvg=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=

--- a/internal/provider/resource_definition_resource_test.go
+++ b/internal/provider/resource_definition_resource_test.go
@@ -509,6 +509,9 @@ resource "humanitec_resource_definition" "provision_test" {
 		"awspolicy" = {
 			is_dependent = true
 			match_dependents = %s
+			params = jsonencode({
+				"bucket" = "test-bucket"
+			})
 		}
 	}
 


### PR DESCRIPTION
This enables to specify params to inject when a co-provisioned resource is provisioned.

Ticket: https://humanitec.atlassian.net/browse/WAL-11222