### PR TITLE
doc: Minor clarifications about `id` and `use` fields for `humanitec_resource_type`

### DIFF
--- a/docs/resources/resource_type.md
+++ b/docs/resources/resource_type.md
@@ -14,7 +14,7 @@ Resource Types are templates for resources, which are used to drive Humanitec's 
 
 ```terraform
 resource "humanitec_resource_type" "demo" {
-  id       = "demo-type"
+  id       = "humanitec-org/demo-type"
   name     = "Demo Type"
   category = "Demo category"
   use      = "direct"
@@ -53,8 +53,8 @@ resource "humanitec_resource_type" "demo" {
 
 ### Required
 
-- `id` (String) The ID of the resource type.
-- `use` (String) Kind of dependency between resource of this type and a workload. It should be one of: `direct`, `indirect`, `implicit`.
+- `id` (String) The ID of the resource type. It should start with the Humanitec Organization ID followed by '/'.
+- `use` (String) Kind of dependency between resource of this type and a workload. It should be one of: `direct`, `indirect`.
 
 ### Optional
 

--- a/examples/resources/humanitec_resource_type/resource.tf
+++ b/examples/resources/humanitec_resource_type/resource.tf
@@ -1,5 +1,5 @@
 resource "humanitec_resource_type" "demo" {
-  id       = "demo-type"
+  id       = "humanitec-org/demo-type"
   name     = "Demo Type"
   category = "Demo category"
   use      = "direct"

--- a/internal/provider/resource_resource_type.go
+++ b/internal/provider/resource_resource_type.go
@@ -52,7 +52,7 @@ func (r *ResourceResourceType) Schema(ctx context.Context, req resource.SchemaRe
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: "The ID of the resource type.",
+				MarkdownDescription: "The ID of the resource type. It should start with the Humanitec Organization ID followed by '/'.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -67,7 +67,7 @@ func (r *ResourceResourceType) Schema(ctx context.Context, req resource.SchemaRe
 				Optional:            true,
 			},
 			"use": schema.StringAttribute{
-				MarkdownDescription: "Kind of dependency between resource of this type and a workload. It should be one of: `direct`, `indirect`, `implicit`.",
+				MarkdownDescription: "Kind of dependency between resource of this type and a workload. It should be one of: `direct`, `indirect`.",
 				Required:            true,
 			},
 			"inputs_schema": schema.StringAttribute{


### PR DESCRIPTION
Minor clarifications about `id` and `use` fields for `humanitec_resource_type`, based on the public doc: https://developer.humanitec.com/app-humanitec-io/docs/platform-orchestrator/resources/custom-resource-types/