### PR TITLE
feat: support in-place-driver-change

### DIFF
--- a/docs/resources/resource_definition.md
+++ b/docs/resources/resource_definition.md
@@ -142,6 +142,7 @@ resource "humanitec_resource_definition" "azure-blob" {
 - `driver_account` (String) Security account required by the driver.
 - `driver_inputs` (Attributes) Data that should be passed around split by sensitivity. (see [below for nested schema](#nestedatt--driver_inputs))
 - `force_delete` (Boolean) If set to `true`, will mark the Resource Definition for deletion, even if it affects existing Active Resources.
+- `in_place_driver_change` (Boolean) If set to `true`, the Operator will not delete resources provisioned by the previous driver when `driver_type` changes on a later update; the new driver takes over the existing infrastructure in place. Applies to the Operator provisioning path only.
 - `provision` (Attributes Map) ProvisionDependencies defines resources which are needed to be co-provisioned with the current resource. (see [below for nested schema](#nestedatt--provision))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.29.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
-	github.com/humanitec/humanitec-go-autogen v0.0.0-20250924140420-4ea9a444b38d
+	github.com/humanitec/humanitec-go-autogen v0.0.0-20260722114248-e82e00377cad
 	github.com/justinrixx/retryhttp v1.0.1
 	github.com/stretchr/testify v1.11.1
 	sigs.k8s.io/yaml v1.6.0
@@ -64,7 +64,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/oapi-codegen/runtime v1.1.2 // indirect
+	github.com/oapi-codegen/runtime v1.3.1 // indirect
 	github.com/oklog/run v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/posener/complete v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/humanitec/humanitec-go-autogen v0.0.0-20250924140420-4ea9a444b38d h1:Jqz602f2N8jBm7sFBZD2UxdJzXT/+E5u+fOh1xvfC9M=
-github.com/humanitec/humanitec-go-autogen v0.0.0-20250924140420-4ea9a444b38d/go.mod h1:+fQM19V8FtUz1nC6gsXhMJV9eyB9CVMoBbBV5wjJsuk=
+github.com/humanitec/humanitec-go-autogen v0.0.0-20260722114248-e82e00377cad h1:YP44nnGALleWjkxI0zp8c0HZdnxQTkD+j+vkZ495dZI=
+github.com/humanitec/humanitec-go-autogen v0.0.0-20260722114248-e82e00377cad/go.mod h1:mA6UbmygOdvZSnOep0fSGm5o48hf8QuT8/M1M2YX96o=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
@@ -177,8 +177,8 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQgXIyI=
-github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
+github.com/oapi-codegen/runtime v1.3.1 h1:RgDY6J4OGQLbRXhG/Xpt3vSVqYpHQS7hN4m85+5xB9g=
+github.com/oapi-codegen/runtime v1.3.1/go.mod h1:kOdeacKy7t40Rclb1je37ZLFboFxh+YLy0zaPCMibPY=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/internal/provider/resource_definition_resource.go
+++ b/internal/provider/resource_definition_resource.go
@@ -79,8 +79,9 @@ type DefinitionResourceModel struct {
 	DriverInputs  *DefinitionResourceDriverInputsModel         `tfsdk:"driver_inputs"`
 	Provision     *map[string]DefinitionResourceProvisionModel `tfsdk:"provision"`
 
-	ForceDelete types.Bool     `tfsdk:"force_delete"`
-	Timeouts    timeouts.Value `tfsdk:"timeouts"`
+	ForceDelete         types.Bool     `tfsdk:"force_delete"`
+	InPlaceDriverChange types.Bool     `tfsdk:"in_place_driver_change"`
+	Timeouts            timeouts.Value `tfsdk:"timeouts"`
 }
 
 func (r *ResourceDefinitionResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -173,6 +174,12 @@ func (r *ResourceDefinitionResource) Schema(ctx context.Context, req resource.Sc
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
 			},
+			"in_place_driver_change": schema.BoolAttribute{
+				MarkdownDescription: "If set to `true`, the Operator will not delete resources provisioned by the previous driver when `driver_type` changes on a later update; the new driver takes over the existing infrastructure in place. Applies to the Operator provisioning path only.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
 			"timeouts": timeouts.Attributes(ctx, timeouts.Opts{
 				Delete: true,
 			}),
@@ -255,6 +262,7 @@ func parseResourceDefinitionResponse(res *client.ResourceDefinitionResponse, dat
 	data.Type = types.StringValue(res.Type)
 	data.DriverType = types.StringValue(res.DriverType)
 	data.DriverAccount = parseOptionalString(res.DriverAccount)
+	data.InPlaceDriverChange = types.BoolValue(res.InPlaceDriverChange)
 	data.Provision = parseProvisionInput(res.Provision, data.Provision)
 
 	driverInputs := res.DriverInputs
@@ -477,13 +485,14 @@ func (r *ResourceDefinitionResource) Create(ctx context.Context, req resource.Cr
 	}
 
 	httpResp, err := r.client().CreateResourceDefinitionWithResponse(ctx, r.orgId(), client.CreateResourceDefinitionRequestRequest{
-		Provision:     provision,
-		DriverAccount: data.DriverAccount.ValueStringPointer(),
-		DriverInputs:  driverInputs,
-		DriverType:    data.DriverType.ValueString(),
-		Id:            data.ID.ValueString(),
-		Name:          data.Name.ValueString(),
-		Type:          data.Type.ValueString(),
+		Provision:           provision,
+		DriverAccount:       data.DriverAccount.ValueStringPointer(),
+		DriverInputs:        driverInputs,
+		DriverType:          data.DriverType.ValueString(),
+		Id:                  data.ID.ValueString(),
+		InPlaceDriverChange: data.InPlaceDriverChange.ValueBoolPointer(),
+		Name:                data.Name.ValueString(),
+		Type:                data.Type.ValueString(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to create resource definition, got error: %s", err))
@@ -562,11 +571,12 @@ func (r *ResourceDefinitionResource) Update(ctx context.Context, req resource.Up
 	provision := provisionFromModel(data.Provision)
 
 	httpResp, err := r.client().UpdateResourceDefinitionWithResponse(ctx, r.orgId(), defID, client.UpdateResourceDefinitionRequestRequest{
-		DriverType:    data.DriverType.ValueStringPointer(),
-		DriverAccount: data.DriverAccount.ValueStringPointer(),
-		DriverInputs:  driverInputs,
-		Name:          data.Name.ValueString(),
-		Provision:     provision,
+		DriverType:          data.DriverType.ValueStringPointer(),
+		DriverAccount:       data.DriverAccount.ValueStringPointer(),
+		DriverInputs:        driverInputs,
+		InPlaceDriverChange: data.InPlaceDriverChange.ValueBoolPointer(),
+		Name:                data.Name.ValueString(),
+		Provision:           provision,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(HUM_CLIENT_ERR, fmt.Sprintf("Unable to read definition, got error: %s", err))

--- a/internal/provider/resource_definition_resource_test.go
+++ b/internal/provider/resource_definition_resource_test.go
@@ -61,6 +61,51 @@ func TestAccResourceDefinition(t *testing.T) {
 			importStateVerifyIgnore:      []string{"driver_inputs.secrets_string", "force_delete"},
 		},
 		{
+			name: "S3 - update in_place_driver_change",
+			configCreate: func() string {
+				return testAccResourceDefinitionS3ResourceWithInPlaceDriverChange(fmt.Sprintf("s3-test-%d", timestamp), "us-east-1", false)
+			},
+			resourceAttrNameIDValue:      fmt.Sprintf("s3-test-%d", timestamp),
+			resourceAttrNameUpdateKey:    "in_place_driver_change",
+			resourceAttrNameUpdateValue1: staticString("false"),
+			resourceAttrName:             "humanitec_resource_definition.s3_test",
+			configUpdate: func() string {
+				return testAccResourceDefinitionS3ResourceWithInPlaceDriverChange(fmt.Sprintf("s3-test-%d", timestamp), "us-east-1", true)
+			},
+			resourceAttrNameUpdateValue2: staticString("true"),
+			importStateVerifyIgnore:      []string{"driver_inputs.secrets_string", "force_delete"},
+		},
+		{
+			name: "S3 - update in_place_driver_change (true to false)",
+			configCreate: func() string {
+				return testAccResourceDefinitionS3ResourceWithInPlaceDriverChange(fmt.Sprintf("s3-test-%d", timestamp), "us-east-1", true)
+			},
+			resourceAttrNameIDValue:      fmt.Sprintf("s3-test-%d", timestamp),
+			resourceAttrNameUpdateKey:    "in_place_driver_change",
+			resourceAttrNameUpdateValue1: staticString("true"),
+			resourceAttrName:             "humanitec_resource_definition.s3_test",
+			configUpdate: func() string {
+				return testAccResourceDefinitionS3ResourceWithInPlaceDriverChange(fmt.Sprintf("s3-test-%d", timestamp), "us-east-1", false)
+			},
+			resourceAttrNameUpdateValue2: staticString("false"),
+			importStateVerifyIgnore:      []string{"driver_inputs.secrets_string", "force_delete"},
+		},
+		{
+			name: "S3 - in_place_driver_change defaults to false when unset",
+			configCreate: func() string {
+				return testAccResourceDefinitionS3Resource(fmt.Sprintf("s3-test-%d", timestamp), "us-east-1")
+			},
+			resourceAttrNameIDValue:      fmt.Sprintf("s3-test-%d", timestamp),
+			resourceAttrNameUpdateKey:    "in_place_driver_change",
+			resourceAttrNameUpdateValue1: staticString("false"),
+			resourceAttrName:             "humanitec_resource_definition.s3_test",
+			configUpdate: func() string {
+				return testAccResourceDefinitionS3Resource(fmt.Sprintf("s3-test-%d", timestamp), "us-east-1")
+			},
+			resourceAttrNameUpdateValue2: staticString("false"),
+			importStateVerifyIgnore:      []string{"driver_inputs.secrets_string", "force_delete"},
+		},
+		{
 			name: "S3 - check the driver does not change",
 			configCreate: func() string {
 				return testAccResourceDefinitionS3Resource(fmt.Sprintf("s3-test-%d", timestamp), "us-east-1")
@@ -486,6 +531,24 @@ resource "humanitec_resource_definition" "s3_test" {
   driver_inputs = {}
 }
 `, id, driver_type)
+}
+
+func testAccResourceDefinitionS3ResourceWithInPlaceDriverChange(id, region string, inPlaceDriverChange bool) string {
+	return fmt.Sprintf(`
+resource "humanitec_resource_definition" "s3_test" {
+  id                     = "%s"
+  name                   = "s3-test"
+  type                   = "s3"
+  driver_type            = "humanitec/s3"
+  in_place_driver_change = %t
+
+  driver_inputs = {
+    values_string = jsonencode({
+      "region" = "%s"
+    })
+  }
+}
+`, id, inPlaceDriverChange, region)
 }
 
 func testAccResourceDefinitionPostgresResource(id, name string) string {


### PR DESCRIPTION
## Summary
Adds support for the `in_place_driver_change` field on `humanitec_resource_definition`, mirroring the field recently added to the Humanitec Resource Definition API. When set to `true`, the Operator will not delete resources provisioned by the previous driver on a `driver_type` update, letting the new driver take over the existing infrastructure in place.

## Changes
- Bump `github.com/humanitec/humanitec-go-autogen` to the version exposing `InPlaceDriverChange` on the resource definition request/response types
- Add `in_place_driver_change` as an `Optional`+`Computed` bool attribute (default `false`) on `humanitec_resource_definition`, following the existing `force_delete` pattern
- Wire the field through `Create`, `Update`, and `parseResourceDefinitionResponse`
- Add acceptance test coverage: toggling `false → true`, `true → false`, and confirming the default is `false` when unset
- Regenerate `docs/resources/resource_definition.md` via `tfplugindocs`